### PR TITLE
feat: platform paths + macOS packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+tools/
 sshush.pid
 id_*
 *.toml
@@ -8,4 +9,3 @@ openspec/
 ok/
 .vscode/
 .cursor/
-.github/events/push-tag.json

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -7,34 +7,52 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	sshagent "golang.org/x/crypto/ssh/agent"
 )
 
-func TestListenAndServe_ListKeys(t *testing.T) {
-	dir := t.TempDir()
-	socketPath := filepath.Join(dir, "agent.sock")
+func unixSocketTempDir(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return t.TempDir()
+	}
+	dir, err := os.MkdirTemp("/tmp", "sshush-a-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
 
+// startServerKeyring starts ListenAndServe with an in-memory keyring,
+// adds one key with the given comment, and returns a connected client.
+func startServerKeyring(t *testing.T, keyComment string) (socketPath string, client sshagent.Agent) {
+	t.Helper()
+	dir := unixSocketTempDir(t)
+	socketPath = filepath.Join(dir, "agent.sock")
 	keyring := sshagent.NewKeyring()
+	ext := keyring.(sshagent.ExtendedAgent)
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = keyring.Add(sshagent.AddedKey{PrivateKey: priv, Comment: "test"})
-	if err != nil {
+	if err := ext.Add(sshagent.AddedKey{PrivateKey: priv, Comment: keyComment}); err != nil {
 		t.Fatal(err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	t.Cleanup(func() {
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+		os.Remove(socketPath)
+	})
 	go func() {
-		_ = ListenAndServe(ctx, socketPath, keyring.(sshagent.ExtendedAgent))
+		_ = ListenAndServe(ctx, socketPath, ext)
 	}()
 
-	// Wait for server to listen
 	var conn net.Conn
 	for i := 0; i < 50; i++ {
 		conn, err = net.Dial("unix", socketPath)
@@ -46,9 +64,12 @@ func TestListenAndServe_ListKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial socket: %v", err)
 	}
-	defer conn.Close()
+	t.Cleanup(func() { conn.Close() })
+	return socketPath, sshagent.NewClient(conn)
+}
 
-	client := sshagent.NewClient(conn)
+func TestListenAndServe_ListKeys(t *testing.T) {
+	_, client := startServerKeyring(t, "test")
 	keys, err := client.List()
 	if err != nil {
 		t.Fatalf("list keys: %v", err)
@@ -59,47 +80,10 @@ func TestListenAndServe_ListKeys(t *testing.T) {
 	if keys[0].Comment != "test" {
 		t.Errorf("comment: want %q, got %q", "test", keys[0].Comment)
 	}
-
-	cancel()
-	time.Sleep(50 * time.Millisecond)
-	os.Remove(socketPath)
 }
 
 func TestListenAndServe_Sign(t *testing.T) {
-	dir := t.TempDir()
-	socketPath := filepath.Join(dir, "agent.sock")
-
-	keyring := sshagent.NewKeyring()
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = keyring.Add(sshagent.AddedKey{PrivateKey: priv, Comment: "sign-test"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		_ = ListenAndServe(ctx, socketPath, keyring.(sshagent.ExtendedAgent))
-	}()
-
-	var conn net.Conn
-	for i := 0; i < 50; i++ {
-		conn, err = net.Dial("unix", socketPath)
-		if err == nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("dial socket: %v", err)
-	}
-	defer conn.Close()
-
-	client := sshagent.NewClient(conn)
+	_, client := startServerKeyring(t, "sign-test")
 	keys, err := client.List()
 	if err != nil {
 		t.Fatalf("list keys: %v", err)
@@ -116,8 +100,4 @@ func TestListenAndServe_Sign(t *testing.T) {
 	if err := keys[0].Verify(data, sig); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
-
-	cancel()
-	time.Sleep(50 * time.Millisecond)
-	os.Remove(socketPath)
 }

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -46,12 +47,28 @@ func writeTestKey(t *testing.T, dir, filename, comment string) string {
 	return privPath
 }
 
+// unixSocketTempDir returns a temp directory with a short path so Unix socket
+// paths fit sockaddr_un (e.g. macOS limits sun_path to 103 bytes; t.TempDir()
+// under /var/folders/... often exceeds that).
+func unixSocketTempDir(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return t.TempDir()
+	}
+	dir, err := os.MkdirTemp("/tmp", "sshush-a-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 // startTestAgent starts an in-process SSH agent on a temp unix socket.
 // Returns the socket path and an agent client. The agent is shut down
 // when the test completes.
 func startTestAgent(t *testing.T) (socketPath string, client sshagent.ExtendedAgent) {
 	t.Helper()
-	dir := t.TempDir()
+	dir := unixSocketTempDir(t)
 	socketPath = filepath.Join(dir, "agent.sock")
 
 	keyring := sshagent.NewKeyring()

--- a/internal/platform/doc.go
+++ b/internal/platform/doc.go
@@ -1,0 +1,2 @@
+// Package platform provides OS-portable defaults for config, runtime paths, and shell setup.
+package platform

--- a/internal/platform/paths.go
+++ b/internal/platform/paths.go
@@ -1,0 +1,54 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// SocketFileName is the default Unix socket filename under the runtime data dir.
+	SocketFileName = "sshush.sock"
+	// PidFileName is the sshushd pidfile name under the runtime data dir.
+	PidFileName = "sshush.pid"
+	// ConfigFileName is the config file name inside the config directory.
+	ConfigFileName = "config.toml"
+)
+
+// ConfigDir returns the absolute path to the sshush config directory:
+// $XDG_CONFIG_HOME/sshush when XDG_CONFIG_HOME is set, otherwise ~/.config/sshush.
+func ConfigDir() string {
+	if d := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); d != "" {
+		return filepath.Join(d, "sshush")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".config", "sshush")
+	}
+	return filepath.Join(home, ".config", "sshush")
+}
+
+// DefaultConfigPath returns the absolute path to the default config file.
+func DefaultConfigPath() string {
+	return filepath.Join(ConfigDir(), ConfigFileName)
+}
+
+// RuntimeDataDir returns the directory for the agent socket and pidfile.
+// Uses $XDG_RUNTIME_DIR when set (typical on Linux desktop sessions).
+// Otherwise falls back to ConfigDir so paths stay absolute without XDG (typical on macOS).
+func RuntimeDataDir() string {
+	if d := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); d != "" {
+		return d
+	}
+	return ConfigDir()
+}
+
+// DefaultSocketPath returns the default absolute path to the agent socket.
+func DefaultSocketPath() string {
+	return filepath.Join(RuntimeDataDir(), SocketFileName)
+}
+
+// DefaultPidFilePath returns the default absolute path to the sshushd pidfile.
+func DefaultPidFilePath() string {
+	return filepath.Join(RuntimeDataDir(), PidFileName)
+}

--- a/internal/platform/paths_test.go
+++ b/internal/platform/paths_test.go
@@ -1,0 +1,55 @@
+package platform
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigDir_respectsXDG_CONFIG_HOME(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "xdgcfg"))
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	want := filepath.Join(tmp, "xdgcfg", "sshush")
+	if got := ConfigDir(); got != want {
+		t.Fatalf("ConfigDir: got %q, want %q", got, want)
+	}
+}
+
+func TestRuntimeDataDir_fallsBackToConfigDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	cfgDir := filepath.Join(tmp, ".config", "sshush")
+	if got := RuntimeDataDir(); got != cfgDir {
+		t.Fatalf("RuntimeDataDir: got %q, want %q", got, cfgDir)
+	}
+}
+
+func TestRuntimeDataDir_prefersXDG_RUNTIME_DIR(t *testing.T) {
+	tmp := t.TempDir()
+	rt := filepath.Join(tmp, "run")
+	t.Setenv("XDG_RUNTIME_DIR", rt)
+
+	if got := RuntimeDataDir(); got != rt {
+		t.Fatalf("RuntimeDataDir: got %q, want %q", got, rt)
+	}
+}
+
+func TestDefaultSocketPath_absoluteWithoutXDG(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	p := DefaultSocketPath()
+	if !filepath.IsAbs(p) {
+		t.Fatalf("expected absolute path, got %q", p)
+	}
+	if filepath.Base(p) != SocketFileName {
+		t.Fatalf("basename: got %q, want %q", filepath.Base(p), SocketFileName)
+	}
+}

--- a/internal/platform/shell.go
+++ b/internal/platform/shell.go
@@ -1,0 +1,48 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+)
+
+const EvalLine = "eval $(sshush)\n"
+
+// ShellRcPathForAutoSetup returns the shell rc file sshush may append EvalLine to.
+// ok is false if there is no reasonable target (e.g. no home directory).
+func ShellRcPathForAutoSetup() (rcPath string, ok bool) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+
+	shell := strings.TrimSpace(os.Getenv("SHELL"))
+	base := filepath.Base(shell)
+
+	switch {
+	case strings.Contains(base, "zsh"):
+		return filepath.Join(home, ".zshrc"), true
+	case strings.Contains(base, "bash"):
+		return filepath.Join(home, ".bashrc"), true
+	case goruntime.GOOS == "darwin":
+		// Default login shell on macOS is zsh; SHELL may be empty in some contexts.
+		return filepath.Join(home, ".zshrc"), true
+	default:
+		bashRC := filepath.Join(home, ".bashrc")
+		zshRC := filepath.Join(home, ".zshrc")
+		if fileExistsRegular(bashRC) {
+			return bashRC, true
+		}
+		if fileExistsRegular(zshRC) {
+			return zshRC, true
+		}
+		// Prefer bashrc on non-macOS when neither exists (common Linux default).
+		return bashRC, true
+	}
+}
+
+func fileExistsRegular(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}

--- a/internal/platform/shell_test.go
+++ b/internal/platform/shell_test.go
@@ -1,0 +1,36 @@
+package platform
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestShellRcPathForAutoSetup_zsh(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	got, ok := ShellRcPathForAutoSetup()
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := filepath.Join(tmp, ".zshrc")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestShellRcPathForAutoSetup_bash(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SHELL", "/usr/bin/bash")
+
+	got, ok := ShellRcPathForAutoSetup()
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := filepath.Join(tmp, ".bashrc")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -7,25 +7,31 @@ import (
 	"strings"
 
 	"github.com/ollykeran/sshush/internal/config"
+	"github.com/ollykeran/sshush/internal/platform"
 	"github.com/ollykeran/sshush/internal/style"
 	"github.com/ollykeran/sshush/internal/utils"
 	"github.com/spf13/cobra"
 )
 
-const defaultConfigPath = "~/.config/sshush/config.toml"
+const defaultServerPidFileName = "sshush-server.pid"
 
-const defaultSocketFileName = "sshush.sock"
-const defaultPidFileName = "sshush.pid"
+func getXDGRuntimeDir() string {
+	return strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR"))
+}
+
+func defaultConfigPathHuman() string {
+	return utils.ContractHomeDirectory(platform.DefaultConfigPath())
+}
 
 // configPath returns the config path using the standard order (--config flag,
-// ~/.config/sshush/config.toml if it exists, SSHUSH_CONFIG, ./config.toml if it exists,
+// default config path if it exists, SSHUSH_CONFIG, ./config.toml if it exists,
 // else default path). Does not require the file to exist.
 func configPath(cmd *cobra.Command) string {
 	if cmd != nil && cmd.Flags().Changed("config") {
 		p, _ := cmd.Flags().GetString("config")
 		return utils.ExpandHomeDirectory(p)
 	}
-	expanded := utils.ExpandHomeDirectory(defaultConfigPath)
+	expanded := platform.DefaultConfigPath()
 	if _, err := os.Stat(expanded); err == nil {
 		return expanded
 	}
@@ -38,6 +44,12 @@ func configPath(cmd *cobra.Command) string {
 	return expanded
 }
 
+// ConfigPathDefault returns the config file path using the same resolution as the CLI
+// when no --config flag is set. The file may not exist.
+func ConfigPathDefault() string {
+	return configPath(nil)
+}
+
 // ResolveConfigPath returns the config file path (see configPath). The path is always
 // returned; error is non-nil when the file does not exist, so callers that need the
 // file must check err. Theme show/list/set can use the path regardless and handle
@@ -46,8 +58,8 @@ func ResolveConfigPath(cmd *cobra.Command) (string, error) {
 	path := configPath(cmd)
 	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
 		return path, style.NewOutput().
-			Error("config file not found").
-			Info("create " + defaultConfigPath + " or use --config").
+			Error("config file not found: " + utils.DisplayPath(path)).
+			Info("create " + defaultConfigPathHuman() + " or use --config").
 			AsError()
 	}
 	return path, nil
@@ -58,27 +70,26 @@ func ResolveDaemonConfigPath() string {
 	if p := os.Getenv("SSHUSH_CONFIG"); p != "" {
 		return utils.ExpandHomeDirectory(p)
 	}
-	return utils.ExpandHomeDirectory(defaultConfigPath)
-}
-
-func getXDGRuntimeDir() string {
-	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
-		return dir
-	}
-	return ""
+	return platform.DefaultConfigPath()
 }
 
 // PidFilePath returns the standard location for the sshushd pidfile.
-// Uses $XDG_RUNTIME_DIR/sshush.pid if available, otherwise ~/.config/sshush/sshush.pid.
+// Uses $XDG_RUNTIME_DIR when set, otherwise the same directory as the default config (see platform.RuntimeDataDir).
 func PidFilePath() string {
-	runtimeDir := getXDGRuntimeDir()
-	if runtimeDir != "" {
-		return filepath.Join(runtimeDir, defaultPidFileName)
-	}
-	return utils.ExpandHomeDirectory("~/.config/sshush/sshush.pid")
+	return platform.DefaultPidFilePath()
 }
 
-// ResolveSocketPath returns socket path from config first, then SSH_AUTH_SOCK.
+// ServerPidFilePath returns the standard location for the SSH server daemon pidfile.
+// Uses $XDG_RUNTIME_DIR when set, otherwise the config directory (see platform.ConfigDir).
+func ServerPidFilePath() string {
+	if d := getXDGRuntimeDir(); d != "" {
+		return filepath.Join(d, defaultServerPidFileName)
+	}
+	return filepath.Join(platform.ConfigDir(), defaultServerPidFileName)
+}
+
+// ResolveSocketPath returns socket path from config first, then SSH_AUTH_SOCK,
+// then the default under platform.RuntimeDataDir.
 func ResolveSocketPath(cfg *config.Config) (string, error) {
 	if cfg != nil && strings.TrimSpace(cfg.SocketPath) != "" {
 		return cfg.SocketPath, nil
@@ -86,13 +97,18 @@ func ResolveSocketPath(cfg *config.Config) (string, error) {
 	if p := strings.TrimSpace(os.Getenv("SSH_AUTH_SOCK")); p != "" {
 		return p, nil
 	}
-	if runtimeDir := getXDGRuntimeDir(); runtimeDir != "" {
-		return filepath.Join(runtimeDir, defaultSocketFileName), nil
+	return platform.DefaultSocketPath(), nil
+}
+
+// SocketPathForSSHushGUI returns the Unix socket that sshushd listens on for this install.
+// Unlike [ResolveSocketPath], it never uses SSH_AUTH_SOCK, so a desktop session where
+// SSH_AUTH_SOCK points at another agent (gnome-keyring, etc.) still targets the sshush
+// socket from config or the default under platform.RuntimeDataDir.
+func SocketPathForSSHushGUI(cfg *config.Config) (string, error) {
+	if cfg != nil && strings.TrimSpace(cfg.SocketPath) != "" {
+		return cfg.SocketPath, nil
 	}
-	return "", style.NewOutput().
-		Error("socket path required").
-		Info("export SSH_AUTH_SOCK or use --socket or --config").
-		AsError()
+	return platform.DefaultSocketPath(), nil
 }
 
 // ResolveEditor returns explicit flag value, then $EDITOR, then fallback.

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -62,7 +62,7 @@ func TestResolveSocketPath_UsesXDGRuntimeDir(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := filepath.Join("/run/user/1000", defaultSocketFileName)
+			want := filepath.Join("/run/user/1000", "sshush.sock")
 			if got != want {
 				t.Fatalf("got %q, want %q", got, want)
 			}
@@ -70,11 +70,51 @@ func TestResolveSocketPath_UsesXDGRuntimeDir(t *testing.T) {
 	})
 }
 
-func TestResolveSocketPath_ErrorWhenUnset(t *testing.T) {
-	withEnv(t, "SSH_AUTH_SOCK", "", func() {
-		withEnv(t, "XDG_RUNTIME_DIR", "", func() {
-			if _, err := ResolveSocketPath(nil); err == nil {
-				t.Fatal("expected error when no config, SSH_AUTH_SOCK, or XDG_RUNTIME_DIR")
+func TestResolveSocketPath_FallbackWhenNoXDG(t *testing.T) {
+	tmp := t.TempDir()
+	withEnv(t, "HOME", tmp, func() {
+		withEnv(t, "SSH_AUTH_SOCK", "", func() {
+			withEnv(t, "XDG_RUNTIME_DIR", "", func() {
+				withEnv(t, "XDG_CONFIG_HOME", "", func() {
+					got, err := ResolveSocketPath(nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+					want := filepath.Join(tmp, ".config", "sshush", "sshush.sock")
+					if got != want {
+						t.Fatalf("got %q, want %q", got, want)
+					}
+				})
+			})
+		})
+	})
+}
+
+func TestSocketPathForSSHushGUI_IgnoresSSHAuthSock(t *testing.T) {
+	withEnv(t, "SSH_AUTH_SOCK", "/wrong/gnome-keyring/ssh", func() {
+		withEnv(t, "XDG_RUNTIME_DIR", "/run/user/1000", func() {
+			got, err := SocketPathForSSHushGUI(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Join("/run/user/1000", "sshush.sock")
+			if got != want {
+				t.Fatalf("got %q, want %q (must not use SSH_AUTH_SOCK)", got, want)
+			}
+		})
+	})
+}
+
+func TestSocketPathForSSHushGUI_ConfigWins(t *testing.T) {
+	withEnv(t, "SSH_AUTH_SOCK", "/env/other.sock", func() {
+		withEnv(t, "XDG_RUNTIME_DIR", "/run/user/1000", func() {
+			cfg := &config.Config{SocketPath: "/custom/sshush.sock"}
+			got, err := SocketPathForSSHushGUI(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != "/custom/sshush.sock" {
+				t.Fatalf("got %q", got)
 			}
 		})
 	})
@@ -83,10 +123,25 @@ func TestResolveSocketPath_ErrorWhenUnset(t *testing.T) {
 func TestPidFilePath_UsesXDGRuntimeDir(t *testing.T) {
 	withEnv(t, "XDG_RUNTIME_DIR", "/run/user/1000", func() {
 		got := PidFilePath()
-		want := filepath.Join("/run/user/1000", defaultPidFileName)
+		want := filepath.Join("/run/user/1000", "sshush.pid")
 		if got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}
+	})
+}
+
+func TestPidFilePath_FallbackWithoutXDG(t *testing.T) {
+	tmp := t.TempDir()
+	withEnv(t, "HOME", tmp, func() {
+		withEnv(t, "XDG_RUNTIME_DIR", "", func() {
+			withEnv(t, "XDG_CONFIG_HOME", "", func() {
+				got := PidFilePath()
+				want := filepath.Join(tmp, ".config", "sshush", "sshush.pid")
+				if got != want {
+					t.Fatalf("got %q, want %q", got, want)
+				}
+			})
+		})
 	})
 }
 

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -8,14 +8,22 @@ import (
 	"github.com/ollykeran/sshush/internal/openssh"
 )
 
-// ExpandHomeDirectory replaces ~ with the current user's home directory.
+// ExpandHomeDirectory expands a leading "~" or "~/" for the current user only.
+// Paths like "~otheruser/foo" are left unchanged.
 func ExpandHomeDirectory(path string) string {
-	if strings.Contains(path, "~") {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		return strings.ReplaceAll(path, "~", homeDir)
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return path
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	if path == "~" {
+		return homeDir
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(homeDir, path[2:])
 	}
 	return path
 }
@@ -33,6 +41,19 @@ func ContractHomeDirectory(path string) string {
 		return "~" + string(filepath.Separator) + path[len(homeDir)+1:]
 	}
 	return path
+}
+
+// DisplayPath formats a path for user-visible output: it is made absolute when
+// possible, then ContractHomeDirectory is applied so paths under $HOME use ~.
+func DisplayPath(path string) string {
+	if path == "" {
+		return path
+	}
+	p := path
+	if abs, err := filepath.Abs(path); err == nil {
+		p = abs
+	}
+	return ContractHomeDirectory(p)
 }
 
 // DiscoverKeyPaths finds valid private key files in searchDirs.

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -18,6 +18,8 @@ func TestExpandHomeDirectory(t *testing.T) {
 		want string
 	}{
 		{"home directory", "~/id_rsa", filepath.Join(homeDir, "id_rsa")},
+		{"tilde only", "~", homeDir},
+		{"tilde in middle unchanged", filepath.Join("a", "~", "b"), filepath.Join("a", "~", "b")},
 		{"relative path", "./id_rsa", "./id_rsa"},
 		{"absolute path", filepath.Join(homeDir, "id_rsa"), filepath.Join(homeDir, "id_rsa")},
 	}
@@ -53,5 +55,21 @@ func TestContractHomeDirectory(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDisplayPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	absUnderHome := filepath.Join(homeDir, "foo", "bar")
+	got := DisplayPath(absUnderHome)
+	want := filepath.Join("~", "foo", "bar")
+	if got != want {
+		t.Errorf("under home: got %q, want %q", got, want)
+	}
+	if got := DisplayPath(""); got != "" {
+		t.Errorf("empty: got %q", got)
 	}
 }

--- a/justfile
+++ b/justfile
@@ -63,8 +63,32 @@ build-sshushd: deps
 build: build-sshushd
     go build -ldflags '-X github.com/ollykeran/sshush/internal/version.Version={{ version }}' -o {{ binary }} ./cmd/sshush
 
-test:
-    go test ./... -v -race
+test pkg="./...":
+    go test {{ if pkg == "./..." { pkg } else { "./" + pkg } }} -v -race
+
+# Cross-compile macOS to build/darwin-<goarch>/ (goarch: arm64 | amd64). Used by tarballs and build-mac.
+build-darwin goarch: deps
+    mkdir -p {{ build_dir }}/darwin-{{ goarch }}
+    CGO_ENABLED=0 GOOS=darwin GOARCH={{ goarch }} go build -ldflags '-X github.com/ollykeran/sshush/internal/version.Version={{ version }}' -o {{ build_dir }}/darwin-{{ goarch }}/sshushd ./cmd/sshushd
+    CGO_ENABLED=0 GOOS=darwin GOARCH={{ goarch }} go build -ldflags '-X github.com/ollykeran/sshush/internal/version.Version={{ version }}' -o {{ build_dir }}/darwin-{{ goarch }}/sshush ./cmd/sshush
+
+# Copies build/darwin-<arch>/ into build/sshush(d). On Darwin, arch matches the machine. Else cross-compile; set MAC_ARCH=amd64 for Intel Mac from Linux.
+build-mac:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "$(uname -s)" == Darwin ]]; then
+      case "$(uname -m)" in
+        arm64) goarch=arm64 ;;
+        x86_64) goarch=amd64 ;;
+        *) echo "unsupported Mac architecture: $(uname -m)" >&2; exit 1 ;;
+      esac
+    else
+      goarch="${MAC_ARCH:-arm64}"
+    fi
+    just build-darwin "$goarch"
+    mkdir -p "{{ build_dir }}"
+    cp "{{ build_dir }}/darwin-$goarch/sshush" "{{ binary }}"
+    cp "{{ build_dir }}/darwin-$goarch/sshushd" "{{ binaryd }}"
 
 # Serve godoc at http://localhost:6060 (module-aware, use -http not -http=:6060)
 doc:
@@ -89,10 +113,16 @@ kill:
 tui: kill build
     {{ binary }} tui
 
-package: tarball deb rpm source archlinux
+package: tarball tarball-darwin-arm64 tarball-darwin-amd64 deb rpm source archlinux
 
 tarball: build
     tar czf {{ build_dir }}/sshush-{{ version }}-linux-amd64.tar.gz -C {{ build_dir }} sshush sshushd
+
+tarball-darwin-arm64: (build-darwin "arm64")
+    tar czf {{ build_dir }}/sshush-{{ version }}-darwin-arm64.tar.gz -C {{ build_dir }}/darwin-arm64 sshush sshushd
+
+tarball-darwin-amd64: (build-darwin "amd64")
+    tar czf {{ build_dir }}/sshush-{{ version }}-darwin-amd64.tar.gz -C {{ build_dir }}/darwin-amd64 sshush sshushd
 
 deb: build
     VERSION={{ version }} nfpm pkg --packager deb --target {{ build_dir }}/sshush-{{ version }}-amd64.deb
@@ -132,10 +162,34 @@ check-artifacts ver="dev":
     check "$dir/sshush"                                "ELF"
     check "$dir/sshushd"                               "ELF"
     check "$dir/sshush-{{ ver }}-linux-amd64.tar.gz"   "gzip"
+    check "$dir/sshush-{{ ver }}-darwin-arm64.tar.gz"  "gzip"
+    check "$dir/sshush-{{ ver }}-darwin-amd64.tar.gz"  "gzip"
     check "$dir/sshush-{{ ver }}-amd64.deb"            "Debian"
     check "$dir/sshush-{{ ver }}-amd64.rpm"            "RPM"
     check "$dir/sshush-{{ ver }}.src.rpm"              "RPM"
     check "$dir/sshush-{{ ver }}-amd64.pkg.tar.zst"    "Zstandard"
+    echo
+    echo "Darwin tarball contents (sshush binary):"
+    for pair in "sshush-{{ ver }}-darwin-arm64.tar.gz:arm64" "sshush-{{ ver }}-darwin-amd64.tar.gz:x86_64"; do
+      tzf="${pair%%:*}"
+      want="${pair##*:}"
+      tmp=$(mktemp)
+      if ! tar xOzf "$dir/$tzf" sshush >"$tmp" 2>/dev/null; then
+        echo "FAIL  $tzf  (could not extract sshush from tarball)"
+        rm -f "$tmp"
+        fail=$((fail + 1))
+        continue
+      fi
+      inner=$(file -b "$tmp" 2>/dev/null || true)
+      rm -f "$tmp"
+      if echo "$inner" | grep -qi "Mach-O.*$want"; then
+        echo "OK    $tzf  ($inner)"
+        pass=$((pass + 1))
+      else
+        echo "FAIL  $tzf  (expected Mach-O $want, got $inner)"
+        fail=$((fail + 1))
+      fi
+    done
     echo
     echo "$pass passed, $fail failed"
     [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
- Add `internal/platform` for config/runtime path helpers and shell rc paths
- Route `internal/runtime` through platform defaults; add display-path helpers
- Fix macOS Unix socket length in agent/CLI tests (`/tmp` short dirs)
- Add Darwin `just` build/tarball recipes and ignore `tools/`

## Test plan
- [x] `just test` on Linux CI
- [x] `just test` on macOS (socket path tests)
- [x] `just build-darwin arm64` (or `build-mac`) produces binaries