### PR TITLE
feat: sectioned config + flat TOML migration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,8 @@ High-level package layout and data flow. For detailed TUI architecture, see [TUI
 - **cmd/sshushd** – Daemon entry point (runs the agent)
 - **internal/agent** – SSH agent logic, socket ops, key list/add/remove
 - **internal/cli** – Cobra commands (start, stop, list, add, remove, reload, create, edit, export, find, tui, completion)
-- **internal/config** – Config load, default creation, bashrc setup
+- **internal/config** – Config load, default creation, shell rc setup
+- **internal/platform** – Portable defaults for config dir, socket/pid paths, shell rc selection
 - **internal/keys** – Key generation, load, save, comment edit, format
 - **internal/openssh** – OpenSSH key parsing
 - **internal/runtime** – Config/socket path resolution

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,8 +1,95 @@
 # Config Reference
 
-Config file: `~/.config/sshush/config.toml`. Override with `-c` / `--config` or set `SSHUSH_CONFIG`.
+Config file: `$XDG_CONFIG_HOME/sshush/config.toml` when `XDG_CONFIG_HOME` is set, otherwise `~/.config/sshush/config.toml`. Override with `-c` / `--config` or set `SSHUSH_CONFIG`.
 
-**Config path resolution** (CLI): `--config` flag, then `~/.config/sshush/config.toml`, then `$SSHUSH_CONFIG`, then `./config.toml`. Daemon uses `$SSHUSH_CONFIG` or `~/.config/sshush/config.toml`.
+To write that default file yourself (or emit it elsewhere), use `sshush generate config [path]`; omit `path` for the standard location. Add `--force` to replace an existing file.
+
+**Config path resolution** (CLI): `--config` flag, then the default config path above if that file exists, then `$SSHUSH_CONFIG`, then `./config.toml` if it exists, else the default path. Daemon uses `$SSHUSH_CONFIG` or the same default path.
+
+## Layout
+
+Options are grouped into TOML tables:
+
+| Section | Purpose |
+|---------|---------|
+| `[agent]` | Socket path, key paths, vault mode flag |
+| `[vault]` | Vault file path; required when `[agent].vault` is true, optional when false (for `sshush vault` CLI while the agent uses `key_paths`) |
+| `[server]` | TCP SSH server listen port and related paths |
+| `[theme]` | Colours (preset or custom hex) |
+
+### Migration from flat TOML (breaking)
+
+Older releases used top-level keys. Move values into the tables above. CLI overrides (`-c`, `-s` / `--socket`, extra key paths on the command line) behave the same.
+
+**Checklist:**
+
+1. Move `socket_path`, `key_paths`, and any vault flag into `[agent]`.
+2. Add `vault = false` (or `true` for vault mode) under `[agent]`.
+3. Move `vault_path` into `[vault]` when you use vault mode or `sshush vault` CLI commands.
+4. Rename server keys: `server_listen` → `[server].listen_port`, `server_authorized_keys` → `[server].authorized_keys`, `server_host_key` → `[server].host_key`.
+5. Keep `[theme]` as-is.
+6. Run `sshush reload` after editing, or restart with `sshush stop` then `eval $(sshush)`.
+
+**Before (flat, master-era):**
+
+```toml
+socket_path = "~/.ssh/sshush.sock"
+key_paths   = ["~/.ssh/id_ed25519"]
+
+[theme]
+name = "dracula"
+```
+
+**After (sectioned, keys-only agent):**
+
+```toml
+[agent]
+socket_path = "~/.ssh/sshush.sock"
+vault       = false
+key_paths   = ["~/.ssh/id_ed25519"]
+
+[theme]
+name = "dracula"
+```
+
+**Before (flat with optional server):**
+
+```toml
+socket_path = "~/.ssh/sshush.sock"
+key_paths   = ["~/.ssh/id_ed25519"]
+# vault_path = "~/.ssh/vault.json"
+
+server_listen          = 2222
+server_authorized_keys = "~/.ssh/authorized_keys"
+server_host_key        = "~/.ssh/host_key"
+
+[theme]
+name = "dracula"
+```
+
+**After (sectioned with server):**
+
+```toml
+[agent]
+socket_path = "~/.ssh/sshush.sock"
+vault       = false
+key_paths   = ["~/.ssh/id_ed25519"]
+
+# [vault]
+# vault_path = "~/.ssh/vault.json"
+
+[server]
+listen_port     = 2222
+authorized_keys = "~/.ssh/authorized_keys"
+host_key        = "~/.ssh/host_key"
+
+[theme]
+name = "dracula"
+```
+
+For vault-only use, set `[agent].vault = true`, put `vault_path` under `[vault]`, and omit or adjust `key_paths` as needed.
+
+To run the agent from `key_paths` but still point `sshush vault list` (and other vault commands) at a file, set `[agent].vault = false`, keep `key_paths`, and set `[vault].vault_path`. The daemon uses the keyring; vault commands use the file on disk.
 
 ## Config Flow
 
@@ -28,21 +115,92 @@ flowchart TD
 
 See also: [Setup](setup.md) | [TUI](tui.md)
 
-## Options
+## `[agent]`
 
 | Option | Description | Example |
 |--------|-------------|---------|
-| `socket_path` | Unix socket for the agent | `"$XDG_RUNTIME_DIR/sshush.sock"` or `"~/.ssh/sshush.sock"` |
-| `key_paths` | Paths to private keys to load | `["~/.ssh/id_ed25519", "~/.ssh/id_rsa"]` |
+| `socket_path` | Unix socket for the agent | `"$XDG_RUNTIME_DIR/sshush.sock"` when set, else `"~/.config/sshush/sshush.sock"` (or under `$XDG_CONFIG_HOME`) |
+| `vault` | If true, use `[vault].vault_path` instead of loading only from `key_paths` | `true` / `false` |
+| `key_paths` | Paths to private keys to load when not in vault-only mode (optional when `vault = true` if you add keys after unlock) | `["~/.ssh/id_ed25519"]` |
 
-Example:
+Example (in-memory keyring):
 
 ```toml
-socket_path = "~/.ssh/sshush.sock"
+[agent]
+socket_path = "~/.config/sshush/sshush.sock"
+vault       = false
 key_paths   = ["~/.ssh/id_ed25519", "~/.ssh/id_rsa"]
 ```
 
-CLI overrides: `-s` / `--socket` overrides `socket_path`.
+Example (vault mode):
+
+```toml
+[agent]
+socket_path = "~/.ssh/sshush.sock"
+vault       = true
+
+[vault]
+vault_path = "~/.ssh/vault.json"
+
+[theme]
+name = "dracula"
+```
+
+When `vault` is true, `key_paths` is optional (you add keys with `sshush add` after unlocking). You must set either `vault = true` with `[vault].vault_path`, or `vault = false` with `key_paths` present.
+
+CLI overrides: `-s` / `--socket` overrides `[agent].socket_path`.
+
+## `[vault]`
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `vault_path` | Path to the vault file (plaintext JSON; private keys stored encrypted per-identity). Required when `[agent].vault` is true; optional when false (for `sshush vault` CLI while the agent uses `key_paths`) | `"~/.ssh/vault.json"` |
+
+When `[agent].vault` is false, `[vault].vault_path` is optional and used only by `sshush vault` subcommands. The daemon ignores it and loads from `key_paths` instead.
+
+## `[server]`
+
+The TCP SSH server runs in a **separate daemon process** (not inside the agent). Start it with `sshush server` (or `sshush serve`), stop it with `sshush server stop`. It uses the same config file; no second config.
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `listen_port` | TCP port (integer); omit or `0` = not enabled | `2222` |
+| `authorized_keys` | Path to authorized_keys file; empty = use keys from the agent (and vault when vault mode is on) | `"~/.ssh/authorized_keys"` |
+| `host_key` | Path to host private key file; empty = ephemeral in-memory key for this process | `"~/.ssh/sshush_host_ed25519"` |
+
+```toml
+[server]
+listen_port = 2222
+```
+
+Paths support `~` expansion. Set `listen_port`, then run `sshush server` to start the server daemon. When using agent-backed auth (no `authorized_keys`), the agent must be running first: run `sshush start` before `sshush server`.
+
+## Vault
+
+When `[agent].vault` is true and `[vault].vault_path` points to a vault file, the daemon uses that file instead of loading keys only from `key_paths`. The vault is a single plaintext JSON file (e.g. `vault.json`) so you can inspect its structure; private key material is stored as encrypted blobs per-identity. The master key is derived from your passphrase and is wiped when you run `sshush lock`.
+
+**One-time setup:**
+
+1. Set `[agent].vault = true` and `[vault].vault_path` (e.g. `"~/.ssh/vault.json"`). If you give a directory, `vault.json` is used inside it.
+2. Run `sshush vault init` (optionally `--vault-path ...` if not using config). Set and confirm a passphrase; a 24-word recovery phrase is generated by default (also written as `recovery.txt` next to the vault). Pass `--no-recovery` to skip.
+
+**Master passphrase policy** (applies only at `vault init`, not when unlocking):
+
+- The passphrase must be non-empty (whitespace-only is rejected).
+- Minimum length defaults to 1 character (UTF-8 runes); additional rules (uppercase, lowercase, digits, ASCII specials) are defined in code as `DefaultPassphrasePolicy` in `internal/vault/passphrase_policy.go` and can be tightened over time.
+- Unlock (`sshush start`, `sshush unlock`, recovery flow) does not re-check this policy so existing vaults keep working with passphrases created under older rules.
+
+Strength checks are policy-based (length and character classes), not a statistical entropy estimate.
+
+**Daily use:**
+
+1. Start the agent: `sshush start` (you will be prompted for the passphrase to unlock the vault once per daemon session).
+2. Add keys with the normal add command: `sshush add ~/.ssh/id_ed25519` (or `ssh-add - add`). There is no separate "vault add"; the same `sshush add` sends the key to the agent, and when the agent is a vault, it encrypts and stores it in the vault file.
+3. Lock when done: `sshush lock`. While locked, the agent reports **no** identities (same as OpenSSH agent when locked). Unlock again with `sshush unlock`; if the vault is already unlocked, `sshush unlock` prints that and does not prompt for a passphrase.
+
+If you start the daemon **without** vault mode, it uses the in-memory keyring and keys are never written to a vault file. To use the vault you must have `[agent].vault = true`, `[vault].vault_path` set, have run `vault init` once, and add keys with `sshush add` after unlocking.
+
+If `ssh` still authenticates after lock, check that `SSH_AUTH_SOCK` points at sshush and that OpenSSH is not using another key via `IdentityFile` or a second agent (see `ssh -v`). Use `IdentitiesOnly` and agent-only identity settings if you need strict agent-only auth.
 
 ## Theme
 
@@ -74,8 +232,8 @@ Set theme from the CLI: `sshush theme show`, `sshush theme list`, `sshush theme 
 
 `sshush reload` reconciles the running agent to the config file:
 
-- Keys in `key_paths` that are not loaded are **added**
+- Keys in `[agent].key_paths` that are not loaded are **added**
 - Keys currently in the agent that are **not** in `key_paths` are **removed**
 - Agent state is reset to match the config file
 
-If `socket_path` changes in config, `reload` restarts the daemon with the new socket.
+If `[agent].socket_path` changes in config, `reload` restarts the daemon with the new socket.

--- a/docs/godoc-guide.md
+++ b/docs/godoc-guide.md
@@ -12,7 +12,8 @@ How to add and maintain godoc comments in sshush. Godoc is Go's built-in documen
 ## Current State
 
 Many internal packages already have good doc comments:
-- `internal/config/default.go`: CreateDefaultConfig, SetupConfig, AddEvalToShell
+- `internal/config/default.go`: StandardConfigFile, WriteDefaultConfigFile, CreateDefaultConfig, SetupConfig, AddEvalToShell
+- `internal/utils/path.go`: ExpandHomeDirectory, ContractHomeDirectory, DisplayPath (use `DisplayPath` for any path shown to users)
 - `internal/runtime/runtime.go`: ResolveConfigPath, ResolveDaemonConfigPath, PidFilePath, ResolveSocketPath
 - `internal/cli/root.go`: LoadMergedConfig, LoadOverrides
 
@@ -30,7 +31,7 @@ Gaps: package-level comments, some exported types, `internal/agent`, `internal/k
 ```go
 // Package config loads and creates sshush configuration.
 // Config is read from TOML at ~/.config/sshush/config.toml (or $SSHUSH_CONFIG).
-// SetupConfig creates a default config and adds eval to bashrc on first run.
+// SetupConfig creates a default config and may append eval $(sshush) to the shell rc on first run.
 package config
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,22 +26,31 @@ Both are equivalent. The export line goes to stdout so `eval $(sshush)` works; o
 
 On every run, before loading config, sshush runs `SetupConfig()`. It does two things if needed:
 
-1. **CreateDefaultConfig** (when `~/.config/sshush/config.toml` does not exist):
-  - Creates `~/.config/sshush/` if needed
-  - Scans `~/.ssh` for valid private keys (skips dirs and `.pub` files)
-  - Writes `socket_path` = `$XDG_RUNTIME_DIR/sshush.sock` (when set) 
-  - Writes `key_paths` = discovered keys from `~/.ssh` 
-  - Does not overwrite an existing config
-2. **AddEvalToShell** (when `~/.bashrc` exists and does not already contain `eval $(sshush)`):
-  - Appends `eval $(sshush)` to `~/.bashrc`
-  - Only modifies `~/.bashrc` (not `.bash_profile`); fails if `~/.bashrc` does not exist
+1. **CreateDefaultConfig** (when the default config file does not exist):
+   - Renders that file from an embedded template (`internal/config/default_config.toml.tmpl`) so the layout stays easy to edit in the repo
+   - Creates the config directory: `$XDG_CONFIG_HOME/sshush/` if `XDG_CONFIG_HOME` is set, otherwise `~/.config/sshush/`
+   - Scans `~/.ssh` for valid private keys (skips dirs and `.pub` files)
+   - Writes `[agent].socket_path` (shown with `~` when under your home directory):
+     - `$XDG_RUNTIME_DIR/sshush.sock` when `XDG_RUNTIME_DIR` is set (common on Linux desktops)
+     - otherwise `~/.config/sshush/sshush.sock` (stable on macOS and minimal Linux environments)
+   - Writes `[agent].vault` = false and `[agent].key_paths` = discovered keys from `~/.ssh`
+   - Writes `[theme]` with `name = "default"` and commented custom colour hints
+   - Appends commented-out `[vault]` and `[server]` sections with example keys so you can enable them later
+   - Does not overwrite an existing config
+2. **AddEvalToShell** (when your shell rc file does not already contain `eval $(sshush)`):
+   - Chooses the rc file from `$SHELL` when possible (`zsh` → `~/.zshrc`, `bash` → `~/.bashrc`)
+   - On macOS, defaults to `~/.zshrc` when `SHELL` is empty or not zsh/bash
+   - On other Unix systems, if neither rc file exists yet, sshush may create `~/.bashrc` and add the line
+   - If the rc file already exists, sshush appends the line
 
-## Shell startup (.bashrc / .bash_profile)
+## Shell startup (.zshrc / .bashrc / .bash_profile)
 
-Add this line to `.bashrc` or `.bash_profile` so each new shell gets the agent:
+Add this line so each new shell gets the agent:
 
 ```sh
 eval $(sshush)
 ```
 
-If you use bash and `~/.bashrc` exists, sshush may add it for you on first run (see AddEvalToShell above). Otherwise add it manually. For other shells or `.bash_profile`, add it yourself. On login, `sshush` will start the daemon if needed and export `SSH_AUTH_SOCK` so `ssh`, `git`, and other tools can use your keys.
+On macOS with zsh, put it in `~/.zshrc`. With bash, use `~/.bashrc` or `~/.bash_profile` as you prefer. If sshush auto-setup created or updated your rc file, you may already have this line.
+
+On login, `sshush` will start the daemon if needed and export `SSH_AUTH_SOCK` so `ssh`, `git`, and other tools can use your keys.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/BurntSushi/toml"
 	"github.com/ollykeran/sshush/internal/config"
 )
 
@@ -103,12 +102,11 @@ func TestLoadMergedConfig_missingFileWithKeyOverride_usesEmptyConfig(t *testing.
 
 func writeConfig(t *testing.T, path string, c config.Config) {
 	t.Helper()
-	f, err := os.Create(path)
+	data, err := config.MarshalConfig(c)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
-	if err := toml.NewEncoder(f).Encode(c); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ollykeran/sshush/internal/style"
@@ -19,11 +21,96 @@ type ThemeSection struct {
 	Warning string `toml:"warning"`
 }
 
-// Config holds socket path, key paths, and optional theme from the TOML config file.
+// Config is the runtime view of the TOML file (flat fields for callers).
+// On disk the file uses [agent], [vault], [server], and [theme] sections.
 type Config struct {
-	KeyPaths   []string    `toml:"key_paths"`   // Paths to private keys to load into the agent.
-	SocketPath string      `toml:"socket_path"` // Unix socket path for the agent.
-	Theme      ThemeSection `toml:"theme"`      // Optional theme (preset name or hex keys).
+	KeyPaths   []string // From [agent].key_paths; when AgentVault is false, keys load from these paths.
+	SocketPath string   // From [agent].socket_path.
+	AgentVault bool     // From [agent].vault; when true, sshushd uses VaultPath as the agent backend.
+	VaultPath  string   // From [vault].vault_path; set whenever the file lists a path (also for CLI when AgentVault is false).
+	Theme      ThemeSection
+
+	ServerListenPort     int64  // From [server].listen_port.
+	ServerAuthorizedKeys string // From [server].authorized_keys.
+	ServerHostKey        string // From [server].host_key.
+}
+
+// configDocument matches the on-disk TOML layout.
+type configDocument struct {
+	Agent  agentSection  `toml:"agent"`
+	Vault  vaultSection  `toml:"vault"`
+	Server serverSection `toml:"server"`
+	Theme  ThemeSection  `toml:"theme"`
+}
+
+type agentSection struct {
+	SocketPath string   `toml:"socket_path"`
+	KeyPaths   []string `toml:"key_paths"`
+	Vault      bool     `toml:"vault"`
+}
+
+type vaultSection struct {
+	VaultPath string `toml:"vault_path"`
+}
+
+type serverSection struct {
+	ListenPort     int64  `toml:"listen_port"`
+	AuthorizedKeys string `toml:"authorized_keys"`
+	HostKey        string `toml:"host_key"`
+}
+
+// configDocumentThemePreset is used when encoding theme preset-only (avoid empty hex keys in file).
+type configDocumentThemePreset struct {
+	Agent  agentSection  `toml:"agent"`
+	Vault  vaultSection  `toml:"vault"`
+	Server serverSection `toml:"server"`
+	Theme  struct {
+		Name string `toml:"name"`
+	} `toml:"theme"`
+}
+
+func toDocument(cfg Config) configDocument {
+	a := agentSection{
+		SocketPath: cfg.SocketPath,
+		KeyPaths:   cfg.KeyPaths,
+		Vault:      cfg.AgentVault,
+	}
+	if a.KeyPaths == nil {
+		a.KeyPaths = []string{}
+	}
+	doc := configDocument{Agent: a, Theme: cfg.Theme}
+	if cfg.VaultPath != "" {
+		doc.Vault = vaultSection{VaultPath: cfg.VaultPath}
+	}
+	if cfg.ServerListenPort != 0 || cfg.ServerAuthorizedKeys != "" || cfg.ServerHostKey != "" {
+		doc.Server = serverSection{
+			ListenPort:     cfg.ServerListenPort,
+			AuthorizedKeys: cfg.ServerAuthorizedKeys,
+			HostKey:        cfg.ServerHostKey,
+		}
+	}
+	return doc
+}
+
+func (d configDocument) toPresetDocument(name string) configDocumentThemePreset {
+	return configDocumentThemePreset{
+		Agent:  d.Agent,
+		Vault:  d.Vault,
+		Server: d.Server,
+		Theme: struct {
+			Name string `toml:"name"`
+		}{Name: name},
+	}
+}
+
+// MarshalConfig serializes cfg to canonical sectioned TOML bytes.
+func MarshalConfig(cfg Config) ([]byte, error) {
+	doc := toDocument(cfg)
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // EnsureSSHDirectory creates ~/.ssh with mode 0700 if it does not exist.
@@ -40,23 +127,89 @@ func LoadConfig(path string) (Config, error) {
 		return Config{}, err
 	}
 
-	cfg := Config{}
-	if err := toml.Unmarshal(data, &cfg); err != nil {
+	var doc configDocument
+	if _, err := toml.Decode(string(data), &doc); err != nil {
+		return Config{}, err
+	}
+
+	cfg, err := documentToConfig(&doc)
+	if err != nil {
 		return Config{}, err
 	}
 
 	cfg.SocketPath = utils.ExpandHomeDirectory(cfg.SocketPath)
+	if cfg.SocketPath != "" {
+		absConfigPath, err := filepath.Abs(path)
+		if err != nil {
+			absConfigPath = path
+		}
+		// Relative socket_path (e.g. legacy "sshush.sock" when XDG was unset) must not
+		// depend on the process cwd; anchor it to the config file's directory.
+		if !filepath.IsAbs(cfg.SocketPath) {
+			cfg.SocketPath = filepath.Clean(filepath.Join(filepath.Dir(absConfigPath), cfg.SocketPath))
+		}
+	}
+	cfg.VaultPath = utils.ExpandHomeDirectory(cfg.VaultPath)
+	cfg.ServerAuthorizedKeys = utils.ExpandHomeDirectory(cfg.ServerAuthorizedKeys)
+	cfg.ServerHostKey = utils.ExpandHomeDirectory(cfg.ServerHostKey)
 	for i, p := range cfg.KeyPaths {
 		cfg.KeyPaths[i] = utils.ExpandHomeDirectory(p)
 	}
 
-	if cfg.KeyPaths == nil {
-		return Config{}, style.NewOutput().Error("key_paths is required").AsError()
+	return cfg, nil
+}
+
+// VaultPathForAgent returns the vault file path when the agent should use the vault backend; otherwise empty.
+func (c Config) VaultPathForAgent() string {
+	if !c.AgentVault || c.VaultPath == "" {
+		return ""
 	}
-	if cfg.SocketPath == "" {
-		return Config{}, style.NewOutput().Error("socket_path is required").AsError()
+	return c.VaultPath
+}
+
+// AgentBackendMode returns a short label for the agent storage backend: "vault" or "keys".
+func (c Config) AgentBackendMode() string {
+	if c.VaultPathForAgent() != "" {
+		return "vault"
+	}
+	return "keys"
+}
+
+func documentToConfig(doc *configDocument) (Config, error) {
+	if doc.Agent.SocketPath == "" {
+		return Config{}, style.NewOutput().
+			Error("[agent].socket_path is required").
+			AsError()
 	}
 
+	vaultPath := doc.Vault.VaultPath
+	if doc.Agent.Vault {
+		if vaultPath == "" {
+			return Config{}, style.NewOutput().
+				Error("when [agent].vault is true, [vault].vault_path must be set").
+				AsError()
+		}
+	} else {
+		hasKeys := doc.Agent.KeyPaths != nil
+		hasVaultPath := vaultPath != ""
+		if !hasKeys && !hasVaultPath {
+			return Config{}, style.NewOutput().
+				Error("config must set [agent].key_paths and/or [vault].vault_path when [agent].vault is false").
+				Info("Use key_paths for the agent; optional vault_path for sshush vault commands while the agent uses key_paths.").
+				AsError()
+		}
+	}
+
+	cfg := Config{
+		SocketPath:           doc.Agent.SocketPath,
+		KeyPaths:             doc.Agent.KeyPaths,
+		AgentVault:           doc.Agent.Vault,
+		VaultPath:            vaultPath,
+		Theme:                doc.Theme,
+		ServerListenPort:     doc.Server.ListenPort,
+		ServerAuthorizedKeys: doc.Server.AuthorizedKeys,
+		ServerHostKey:        doc.Server.HostKey,
+	}
 	return cfg, nil
 }
 
@@ -89,11 +242,15 @@ func LoadThemeFromPath(path string) theme.Theme {
 	if err != nil {
 		return theme.DefaultTheme()
 	}
-	var structWithTheme struct {
-		Theme ThemeSection `toml:"theme"`
-	}
-	if err := toml.Unmarshal(data, &structWithTheme); err != nil {
+	var doc configDocument
+	if _, err := toml.Decode(string(data), &doc); err != nil {
 		return theme.DefaultTheme()
 	}
-	return ResolveThemeFromSection(structWithTheme.Theme)
+	return ResolveThemeFromSection(doc.Theme)
+}
+
+func decodeConfigDocument(data []byte) (configDocument, error) {
+	var doc configDocument
+	_, err := toml.Decode(string(data), &doc)
+	return doc, err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/BurntSushi/toml"
 )
 
 func TestLoad(t *testing.T) {
@@ -21,9 +19,13 @@ func TestLoad(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			content := Config{
+			cfg := Config{
 				KeyPaths:   tc.wantKeyPaths,
 				SocketPath: tc.wantSocketPath,
+			}
+			data, err := MarshalConfig(cfg)
+			if err != nil {
+				t.Fatal(err)
 			}
 			tmp, err := os.CreateTemp("", "test-config-*.toml")
 			if err != nil {
@@ -31,23 +33,22 @@ func TestLoad(t *testing.T) {
 			}
 			tmpPath := tmp.Name()
 			defer os.Remove(tmpPath)
-
-			if err := toml.NewEncoder(tmp).Encode(content); err != nil {
+			if _, err := tmp.Write(data); err != nil {
 				t.Fatal(err)
 			}
 			if err := tmp.Close(); err != nil {
 				t.Fatal(err)
 			}
 
-			cfg, err := LoadConfig(tmpPath)
+			got, err := LoadConfig(tmpPath)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(cfg.KeyPaths, tc.wantKeyPaths) {
-				t.Errorf("KeyPaths: got %v, want %v", cfg.KeyPaths, tc.wantKeyPaths)
+			if !reflect.DeepEqual(got.KeyPaths, tc.wantKeyPaths) {
+				t.Errorf("KeyPaths: got %v, want %v", got.KeyPaths, tc.wantKeyPaths)
 			}
-			if cfg.SocketPath != tc.wantSocketPath {
-				t.Errorf("SocketPath: got %q, want %q", cfg.SocketPath, tc.wantSocketPath)
+			if got.SocketPath != tc.wantSocketPath {
+				t.Errorf("SocketPath: got %q, want %q", got.SocketPath, tc.wantSocketPath)
 			}
 		})
 	}
@@ -73,9 +74,13 @@ func TestLoad(t *testing.T) {
 		if err != nil {
 			t.Skip("no home directory available")
 		}
-		content := Config{
+		cfg := Config{
 			KeyPaths:   []string{"~/foo/id_ed25519"},
 			SocketPath: "~/.ssh/sshush.sock",
+		}
+		data, err := MarshalConfig(cfg)
+		if err != nil {
+			t.Fatal(err)
 		}
 		tmp, err := os.CreateTemp("", "tilde-config-*.toml")
 		if err != nil {
@@ -83,23 +88,139 @@ func TestLoad(t *testing.T) {
 		}
 		tmpPath := tmp.Name()
 		defer os.Remove(tmpPath)
-
-		if err := toml.NewEncoder(tmp).Encode(content); err != nil {
+		if _, err := tmp.Write(data); err != nil {
 			t.Fatal(err)
 		}
 		if err := tmp.Close(); err != nil {
 			t.Fatal(err)
 		}
 
-		cfg, err := LoadConfig(tmpPath)
+		loaded, err := LoadConfig(tmpPath)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := cfg.SocketPath; got != filepath.Join(home, ".ssh/sshush.sock") {
+		if got := loaded.SocketPath; got != filepath.Join(home, ".ssh/sshush.sock") {
 			t.Errorf("SocketPath: got %q, want %q", got, filepath.Join(home, ".ssh/sshush.sock"))
 		}
-		if len(cfg.KeyPaths) != 1 || cfg.KeyPaths[0] != filepath.Join(home, "foo/id_ed25519") {
-			t.Errorf("KeyPaths: got %v, want [%q]", cfg.KeyPaths, filepath.Join(home, "foo/id_ed25519"))
+		if len(loaded.KeyPaths) != 1 || loaded.KeyPaths[0] != filepath.Join(home, "foo/id_ed25519") {
+			t.Errorf("KeyPaths: got %v, want [%q]", loaded.KeyPaths, filepath.Join(home, "foo/id_ed25519"))
+		}
+	})
+
+	t.Run("listen_port under server section", func(t *testing.T) {
+		cfg := Config{
+			KeyPaths:         []string{"/tmp/id_ed25519"},
+			SocketPath:       "/tmp/agent.sock",
+			ServerListenPort: 2222,
+		}
+		data, err := MarshalConfig(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmp, err := os.CreateTemp("", "server-config-*.toml")
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmpPath := tmp.Name()
+		defer os.Remove(tmpPath)
+		if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		loaded, err := LoadConfig(tmpPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if loaded.ServerListenPort != 2222 {
+			t.Errorf("ServerListenPort: got %d, want 2222", loaded.ServerListenPort)
+		}
+	})
+
+	t.Run("marshal roundtrip preserves AgentVault and VaultPath", func(t *testing.T) {
+		cfg := Config{
+			SocketPath: "/tmp/s.sock",
+			KeyPaths:   []string{"/tmp/k"},
+			AgentVault: true,
+			VaultPath:  "/tmp/v.json",
+		}
+		data, err := MarshalConfig(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmp := filepath.Join(t.TempDir(), "cfg.toml")
+		if err := os.WriteFile(tmp, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := LoadConfig(tmp)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v\n%s", err, string(data))
+		}
+		if !got.AgentVault || got.VaultPath != "/tmp/v.json" {
+			t.Fatalf("got AgentVault=%v VaultPath=%q", got.AgentVault, got.VaultPath)
+		}
+	})
+
+	t.Run("AgentBackendMode", func(t *testing.T) {
+		cases := []struct {
+			name string
+			cfg  Config
+			want string
+		}{
+			{"vault agent", Config{AgentVault: true, VaultPath: "/v.json"}, "vault"},
+			{"keys only", Config{AgentVault: false, KeyPaths: []string{"/k"}, VaultPath: ""}, "keys"},
+			{"offline vault path keys agent", Config{AgentVault: false, KeyPaths: []string{"/k"}, VaultPath: "/v.json"}, "keys"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if got := tc.cfg.AgentBackendMode(); got != tc.want {
+					t.Fatalf("AgentBackendMode: got %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("vault_path with vault false keeps path for CLI", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.toml")
+		body := "[agent]\nsocket_path = \"/tmp/agent.sock\"\nvault = false\nkey_paths = [\"/tmp/k\"]\n\n[vault]\nvault_path = \"/tmp/vault.json\"\n"
+		if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.AgentVault {
+			t.Fatal("expected AgentVault false")
+		}
+		if cfg.VaultPath != "/tmp/vault.json" {
+			t.Fatalf("VaultPath: got %q", cfg.VaultPath)
+		}
+		if cfg.VaultPathForAgent() != "" {
+			t.Fatalf("VaultPathForAgent: want empty, got %q", cfg.VaultPathForAgent())
+		}
+	})
+
+	t.Run("relative socket_path is resolved against config file directory", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgDir := filepath.Join(dir, "sshush")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(cfgDir, "config.toml")
+		body := "[agent]\nsocket_path = \"sshush.sock\"\nkey_paths = [\"/tmp/dummy-key\"]\nvault = false\n"
+		if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(cfgDir, "sshush.sock")
+		if cfg.SocketPath != want {
+			t.Fatalf("SocketPath: got %q, want %q", cfg.SocketPath, want)
+		}
+		if !filepath.IsAbs(cfg.SocketPath) {
+			t.Fatalf("expected absolute socket path, got %q", cfg.SocketPath)
 		}
 	})
 }

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -1,16 +1,38 @@
 package config
 
 import (
+	"bytes"
+	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/ollykeran/sshush/internal/openssh"
+	"github.com/ollykeran/sshush/internal/platform"
 	"github.com/ollykeran/sshush/internal/style"
 	"github.com/ollykeran/sshush/internal/theme"
 	"github.com/ollykeran/sshush/internal/utils"
 )
+
+//go:embed default_config.toml.tmpl
+var defaultConfigTemplateFS embed.FS
+
+var defaultConfigTemplate = template.Must(
+	template.ParseFS(defaultConfigTemplateFS, "default_config.toml.tmpl"),
+)
+
+// defaultConfigTemplateData is input for default_config.toml.tmpl.
+type defaultConfigTemplateData struct {
+	SocketPath   string
+	KeyPathsTOML string
+	ThemeText    string
+	ThemeFocus   string
+	ThemeAccent  string
+	ThemeError   string
+	ThemeWarning string
+}
 
 func findDefaultKeys() []string {
 	const sshHome = "~/.ssh"
@@ -58,28 +80,11 @@ func findDefaultKeys() []string {
 	return paths
 }
 
-// CreateDefaultConfig creates ~/.config/sshush/config.toml and writes an example
-// config if neither the directory nor the file exist yet.
-func CreateDefaultConfig() error {
-	const defaultConfigDir = "~/.config/sshush"
-	const defaultConfigFileName = "config.toml"
-
-	defaultConfigDirExpanded := utils.ExpandHomeDirectory(defaultConfigDir)
-	defaultConfigFile := filepath.Join(defaultConfigDirExpanded, defaultConfigFileName)
-
-	if err := os.MkdirAll(defaultConfigDirExpanded, 0o755); err != nil {
-		return err
+// keyPathsToTOMLArray formats discovered key paths as a TOML array literal (tilde-prefixed when under $HOME).
+func keyPathsToTOMLArray(keyPaths []string) string {
+	if len(keyPaths) == 0 {
+		return "[]"
 	}
-
-	// Do not overwrite existing config.
-	if _, err := os.Stat(defaultConfigFile); err == nil {
-		return nil
-	}
-
-	// Discover keys.
-	keyPaths := findDefaultKeys()
-
-	// Convert to "~" form for nicer config.
 	home, _ := os.UserHomeDir()
 	quoted := make([]string, len(keyPaths))
 	for i, p := range keyPaths {
@@ -88,70 +93,119 @@ func CreateDefaultConfig() error {
 		}
 		quoted[i] = `"` + p + `"`
 	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
 
-	keyPathLine := "key_paths = [" + strings.Join(quoted, ", ") + "]"
-
-	// Socket path
-	socketPath := filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "sshush.sock")
-	socketPathLine := `socket_path = "` + socketPath + `"`
-
-	def := theme.DefaultTheme()
-	configLines := []string{
-		"# Example config.toml",
-		socketPathLine,
-		keyPathLine,
-		"",
-		"[theme]",
-		`name = "default"`,
-		"# text = \"" + def.Text + "\"",
-		"# focus = \"" + def.Focus + "\"",
-		"# accent = \"" + def.Accent + "\"",
-		"# error = \"" + def.Error + "\"",
-		"# warning = \"" + def.Warning + "\"",
-		"",
+// renderDefaultConfigBytes renders the embedded default config template. Exposed for tests.
+func renderDefaultConfigBytes(socketPath string, keyPaths []string, def theme.Theme) ([]byte, error) {
+	data := defaultConfigTemplateData{
+		SocketPath:   socketPath,
+		KeyPathsTOML: keyPathsToTOMLArray(keyPaths),
+		ThemeText:    def.Text,
+		ThemeFocus:   def.Focus,
+		ThemeAccent:  def.Accent,
+		ThemeError:   def.Error,
+		ThemeWarning: def.Warning,
 	}
+	var buf bytes.Buffer
+	if err := defaultConfigTemplate.Execute(&buf, data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
 
-	config := strings.Join(configLines, "\n")
+// StandardConfigFile returns the absolute path to the default config file.
+func StandardConfigFile() string {
+	return platform.DefaultConfigPath()
+}
 
-	if err := os.WriteFile(defaultConfigFile, []byte(config), 0o644); err != nil {
+// WriteDefaultConfigFile renders the default config template and writes it to path.
+// Parent directories are created as needed. If overwrite is false and path already
+// exists, it returns an error.
+func WriteDefaultConfigFile(path string, overwrite bool) error {
+	if _, err := os.Stat(path); err == nil && !overwrite {
+		return style.NewOutput().
+			Error("config file already exists: " + utils.DisplayPath(path)).
+			Info("use --force to overwrite").
+			AsError()
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
+	keyPaths := findDefaultKeys()
+	socketDisplay := utils.ContractHomeDirectory(platform.DefaultSocketPath())
+	def := theme.DefaultTheme()
+	data, err := renderDefaultConfigBytes(socketDisplay, keyPaths, def)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
 
+// CreateDefaultConfig creates the default config directory and config.toml if the file
+// does not exist yet.
+func CreateDefaultConfig() error {
+	p := platform.DefaultConfigPath()
+	if _, err := os.Stat(p); err == nil {
+		return nil
+	}
+	if err := WriteDefaultConfigFile(p, false); err != nil {
+		return err
+	}
 	fmt.Println("Default config created")
 	return nil
 }
 
-// AddEvalToShell appends "eval $(sshush)" to ~/.bashrc. Fails if ~/.bashrc does not exist.
+// AddEvalToShell appends eval $(sshush) to the preferred shell rc file (see platform.ShellRcPathForAutoSetup).
+// Creates the rc file if it does not exist.
 func AddEvalToShell() error {
-	const line = "eval $(sshush)\n"
-	bashrcPath := utils.ExpandHomeDirectory("~/.bashrc")
-	if _, err := os.Stat(bashrcPath); err != nil {
-		return style.NewOutput().Error("~/.bashrc not found - cannot add eval $(sshush)").AsError()
+	rcPath, ok := platform.ShellRcPathForAutoSetup()
+	if !ok {
+		return style.NewOutput().Error("cannot determine shell rc file (no home directory)").AsError()
 	}
 
-	bashrc, err := os.OpenFile(bashrcPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if _, err := os.Stat(rcPath); os.IsNotExist(err) {
+		header := "# sshush: start agent in new shells\n"
+		if err := os.WriteFile(rcPath, []byte(header+platform.EvalLine), 0o644); err != nil {
+			return style.NewOutput().Error("failed to create " + rcPath + ": " + err.Error()).AsError()
+		}
+		return nil
+	} else if err != nil {
+		return style.NewOutput().Error("cannot read " + rcPath + ": " + err.Error()).AsError()
+	}
+
+	f, err := os.OpenFile(rcPath, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return style.NewOutput().Error("Failed to open ~/.bashrc").AsError()
+		return style.NewOutput().Error("failed to open " + rcPath + ": " + err.Error()).AsError()
 	}
-	defer bashrc.Close()
+	defer f.Close()
 
-	bashrc.WriteString(line)
+	if _, err := f.WriteString(platform.EvalLine); err != nil {
+		return style.NewOutput().Error("failed to write " + rcPath + ": " + err.Error()).AsError()
+	}
 	return nil
 }
 
-// SetupConfig ensures default config exists and eval is added to bashrc if needed.
+// SetupConfig ensures default config exists and eval is added to the shell rc if needed.
 // Call from root PersistentPreRunE or main before loading config.
 func SetupConfig() {
-	const defaultConfigPath = "~/.config/sshush/config.toml"
-	expanded := utils.ExpandHomeDirectory(defaultConfigPath)
+	expanded := platform.DefaultConfigPath()
 
 	if _, err := os.Stat(expanded); os.IsNotExist(err) {
 		_ = CreateDefaultConfig()
 	}
 
-	bashrcPath := utils.ExpandHomeDirectory("~/.bashrc")
-	content, err := os.ReadFile(bashrcPath)
-	if err == nil && !strings.Contains(string(content), "eval $(sshush)") {
-		_ = AddEvalToShell()
+	rcPath, ok := platform.ShellRcPathForAutoSetup()
+	if !ok {
+		return
 	}
+	content, err := os.ReadFile(rcPath)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	if err == nil && strings.Contains(string(content), "eval $(sshush)") {
+		return
+	}
+	_ = AddEvalToShell()
 }

--- a/internal/config/default_config.toml.tmpl
+++ b/internal/config/default_config.toml.tmpl
@@ -1,0 +1,21 @@
+# Example config.toml
+[agent]
+socket_path = {{ printf "%q" .SocketPath }}
+vault = false
+key_paths = {{ .KeyPathsTOML }}
+
+# [vault]
+# vault_path = "~/.config/sshush/vault.json"
+#
+# [server]
+# listen_port = 2222
+# authorized_keys = "~/.ssh/authorized_keys"
+# host_key = "~/.ssh/sshush_host_ed25519"
+
+[theme]
+name = "default"
+# text = {{ printf "%q" .ThemeText }}
+# focus = {{ printf "%q" .ThemeFocus }}
+# accent = {{ printf "%q" .ThemeAccent }}
+# error = {{ printf "%q" .ThemeError }}
+# warning = {{ printf "%q" .ThemeWarning }}

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/ollykeran/sshush/internal/style"
+	"github.com/ollykeran/sshush/internal/theme"
+	"github.com/ollykeran/sshush/internal/utils"
+	ssh "golang.org/x/crypto/ssh"
+)
+
+func TestKeyPathsToTOMLArray(t *testing.T) {
+	t.Parallel()
+	if got := keyPathsToTOMLArray(nil); got != "[]" {
+		t.Errorf("nil: got %q, want []", got)
+	}
+	if got := keyPathsToTOMLArray([]string{}); got != "[]" {
+		t.Errorf("empty: got %q, want []", got)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := []string{filepath.Join(home, ".ssh", "id_ed25519"), "/other/key"}
+	got := keyPathsToTOMLArray(keys)
+	want := `["~/.ssh/id_ed25519", "/other/key"]`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderDefaultConfigBytes_loads(t *testing.T) {
+	t.Parallel()
+	data, err := renderDefaultConfigBytes("/run/user/1000/sshush.sock", []string{"/tmp/id_ed25519"}, theme.DefaultTheme())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp, err := os.CreateTemp("", "default-render-*.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	defer os.Remove(path)
+	if _, err := tmp.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v\n%s", err, string(data))
+	}
+	if cfg.SocketPath != "/run/user/1000/sshush.sock" {
+		t.Errorf("SocketPath: got %q", cfg.SocketPath)
+	}
+	if len(cfg.KeyPaths) != 1 || cfg.KeyPaths[0] != "/tmp/id_ed25519" {
+		t.Errorf("KeyPaths: got %v", cfg.KeyPaths)
+	}
+	if cfg.Theme.Name != "default" {
+		t.Errorf("Theme.Name: got %q", cfg.Theme.Name)
+	}
+}
+
+func TestStandardConfigFile_suffix(t *testing.T) {
+	got := StandardConfigFile()
+	if !strings.HasSuffix(got, filepath.Join(".config", "sshush", "config.toml")) {
+		t.Errorf("StandardConfigFile: got %q", got)
+	}
+}
+
+func TestWriteDefaultConfigFile_existsNoOverwrite(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := WriteDefaultConfigFile(path, false)
+	if err == nil {
+		t.Fatal("expected error when file exists")
+	}
+	var se *style.StyledError
+	if !errors.As(err, &se) {
+		t.Errorf("expected StyledError, got %T", err)
+	}
+}
+
+func TestWriteDefaultConfigFile_overwrite(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "nested", "config.toml")
+	if err := WriteDefaultConfigFile(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDefaultConfigFile(path, true); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "[agent]") {
+		t.Errorf("expected [agent] in written file")
+	}
+}
+
+func TestWriteDefaultConfigFile_loadableWithHomeSSHKey(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	sshDir := filepath.Join(tmp, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTestSSHKeyFile(filepath.Join(sshDir, "id_ed25519")); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(tmp, "out", "config.toml")
+	if err := WriteDefaultConfigFile(out, false); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(out)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !strings.HasSuffix(cfg.SocketPath, "sshush.sock") {
+		t.Errorf("SocketPath: got %q, want suffix sshush.sock", cfg.SocketPath)
+	}
+	if len(cfg.KeyPaths) < 1 {
+		t.Errorf("expected at least one key path, got %v", cfg.KeyPaths)
+	}
+}
+
+func writeTestSSHKeyFile(privPath string) error {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "test")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(privPath, pem.EncodeToMemory(block), 0o600)
+}
+
+func TestCreateDefaultConfig_socketPathAbsoluteWithoutXDG(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	if err := CreateDefaultConfig(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(tmp, ".config")) })
+
+	data, err := os.ReadFile(filepath.Join(tmp, ".config", "sshush", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Agent struct {
+			SocketPath string `toml:"socket_path"`
+		} `toml:"agent"`
+	}
+	if _, err := toml.Decode(string(data), &doc); err != nil {
+		t.Fatal(err)
+	}
+	sp := doc.Agent.SocketPath
+	if sp == "" {
+		t.Fatal("empty [agent].socket_path")
+	}
+	if !strings.HasPrefix(sp, "~") {
+		t.Fatalf("expected contracted socket_path under home, got %q", sp)
+	}
+	expanded := utils.ExpandHomeDirectory(sp)
+	if !filepath.IsAbs(expanded) {
+		t.Fatalf("expanded socket_path not absolute: %q", expanded)
+	}
+}

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,4 +1,6 @@
 // Package config loads and creates sshush configuration from TOML.
-// Config is read from ~/.config/sshush/config.toml (or $SSHUSH_CONFIG).
-// SetupConfig creates a default config and adds eval to bashrc on first run.
+// The file uses tables [agent], [vault], [server], and [theme].
+// Default config path is $XDG_CONFIG_HOME/sshush/config.toml when set, otherwise ~/.config/sshush/config.toml
+// (override with $SSHUSH_CONFIG or --config). SetupConfig creates a default config from an embedded template
+// on first run and may append eval $(sshush) to ~/.zshrc or ~/.bashrc (see internal/platform for rules).
 package config

--- a/internal/config/write_theme.go
+++ b/internal/config/write_theme.go
@@ -12,7 +12,7 @@ import (
 // WriteThemeToPath updates the [theme] section in the config file at path.
 // Use presetName for a preset (e.g. "dracula"); then custom is ignored and only name is written.
 // Use custom (non-nil) for custom hex theme; then presetName is ignored.
-// Preserves existing socket_path, key_paths, and any other content.
+// Preserves existing [agent], [vault], [server], and [theme] content.
 // If the file does not exist, returns an error (use CreateDefaultConfig to create the config first).
 // Uses atomic write (temp file + rename). Path is expanded (~).
 func WriteThemeToPath(path string, presetName string, custom *ThemeSection) error {
@@ -20,26 +20,22 @@ func WriteThemeToPath(path string, presetName string, custom *ThemeSection) erro
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("config file not found: %s (run the app once to create it)", path)
+			return fmt.Errorf("config file not found: %s (run the app once to create it)", utils.DisplayPath(path))
 		}
 		return fmt.Errorf("read config: %w", err)
 	}
 
-	var raw struct {
-		SocketPath string        `toml:"socket_path"`
-		KeyPaths   []string      `toml:"key_paths"`
-		Theme      *ThemeSection `toml:"theme"`
-	}
-	if _, err := toml.Decode(string(data), &raw); err != nil {
+	doc, err := decodeConfigDocument(data)
+	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
 
 	if presetName != "" {
-		raw.Theme = &ThemeSection{Name: presetName}
+		doc.Theme = ThemeSection{Name: presetName}
 	} else if custom != nil {
-		raw.Theme = custom
+		doc.Theme = *custom
 	} else {
-		raw.Theme = &ThemeSection{}
+		doc.Theme = ThemeSection{}
 	}
 
 	dir := filepath.Dir(path)
@@ -50,26 +46,14 @@ func WriteThemeToPath(path string, presetName string, custom *ThemeSection) erro
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 
-	// When writing a preset only, encode theme as just name so we don't emit empty hex fields.
 	if presetName != "" {
-		type presetOnly struct {
-			SocketPath string   `toml:"socket_path"`
-			KeyPaths   []string `toml:"key_paths"`
-			Theme      struct {
-				Name string `toml:"name"`
-			} `toml:"theme"`
-		}
-		out := presetOnly{
-			SocketPath: raw.SocketPath,
-			KeyPaths:   raw.KeyPaths,
-		}
-		out.Theme.Name = presetName
-		if err := toml.NewEncoder(tmp).Encode(out); err != nil {
+		presetDoc := doc.toPresetDocument(presetName)
+		if err := toml.NewEncoder(tmp).Encode(presetDoc); err != nil {
 			tmp.Close()
 			return fmt.Errorf("encode config: %w", err)
 		}
 	} else {
-		if err := toml.NewEncoder(tmp).Encode(raw); err != nil {
+		if err := toml.NewEncoder(tmp).Encode(doc); err != nil {
 			tmp.Close()
 			return fmt.Errorf("encode config: %w", err)
 		}


### PR DESCRIPTION
## Summary
- Parse/write sectioned config (`[agent]`, `[vault]`, `[server]`, `[theme]`)
- Migrate legacy flat TOML on load; update defaults template and tests
- Document breaking migration in setup/config docs

## Stack
- Bases on #46 (`split/platform-macos`) because config defaults use `internal/platform`
- After #46 merges, retarget this PR to `master`

## Test plan
- [x] `go test ./internal/config/ ./internal/cli/ -race`
- [x] Load an old flat `config.toml` and confirm migration succeeds
- [x] New default config loads under sectioned layout