### PR TITLE
feat: SSH server mode

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,24 @@
+name: Mirror to GitLab
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+
+jobs:
+  to_gitlab:
+    runs-on: ubuntu-latest
+    environment: gitlab
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+      - name: Mirror to GitLab
+        run: |
+          GITLAB_URL="https://oauth2:${{ secrets.GITLAB_TOKEN }}@gitlab.com/ollykeran/sshush.git"
+          
+          # Force push all branches and tags to the GitLab mirror
+          git push --prune "$GITLAB_URL" +refs/remotes/origin/*:refs/heads/* +refs/tags/*:refs/tags/*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ That starts the daemon (if needed), loads keys from config, and exports `SSH_AUT
 - **Create/Edit/Export**: Generate keys (`create`), edit comments (`edit`), export public keys (`export`).
 - **TUI**: Interactive terminal UI to manage keys, generate, edit, and export. Run `sshush tui`.
 - **Vault**: Encrypted on-disk key store with lock/unlock and recovery. See [docs/vault.md](docs/vault.md).
+- **SSH server**: Optional TCP SSH server (`sshush server`). See [Config Reference](docs/config.md) `[server]` section.
 - **Reload**: `sshush reload` reconciles the agent to the config file. Keys not in config are removed; keys in config are added. If you change `[agent].socket_path`, the daemon restarts.
 - **Config auto-setup**: On first run, if no config exists, sshush creates the default config under `$XDG_CONFIG_HOME/sshush/` (or `~/.config/sshush/`) with discovered keys and a stable `socket_path` (`$XDG_RUNTIME_DIR/sshush.sock` when set, otherwise `~/.config/sshush/sshush.sock`). You can write the same default file anytime with `sshush generate config` (optional path; use `--force` to overwrite).
 

--- a/cmd/sshushd/main.go
+++ b/cmd/sshushd/main.go
@@ -17,6 +17,7 @@ import (
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.BoolVar(showVersion, "v", false, "print version and exit")
+	serverMode := flag.Bool("server", false, "run TCP SSH server daemon only")
 	flag.Parse()
 	if *showVersion {
 		fmt.Printf("sshushd %s (%s)\n", version.Version, stdruntime.Version())
@@ -28,6 +29,15 @@ func main() {
 	if err != nil {
 		style.NewOutput().Error("sshushd: load config: " + err.Error()).PrintErr()
 		os.Exit(1)
+	}
+
+	if *serverMode {
+		serverPidFilePath := runtime.ServerPidFilePath()
+		if err := sshushd.RunServerOnly(cfg, serverPidFilePath); err != nil {
+			style.NewOutput().Error("sshushd: " + err.Error()).PrintErr()
+			os.Exit(1)
+		}
+		return
 	}
 
 	if sshushd.CheckAlreadyRunning(cfg.SocketPath) {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -22,5 +22,6 @@ func registerCommands(root *cobra.Command) {
 	root.AddCommand(newLockCommand())
 	root.AddCommand(newUnlockCommand())
 	root.AddCommand(newVaultCommand())
+	root.AddCommand(newServerCommand())
 	root.AddCommand(newGenerateCommand())
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ollykeran/sshush/internal/runtime"
+	"github.com/ollykeran/sshush/internal/sshushd"
+	"github.com/ollykeran/sshush/internal/style"
+	"github.com/spf13/cobra"
+)
+
+func newServerCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "server",
+		Aliases: []string{"serve"},
+		Short:   "Start the SSH server daemon",
+		Long:    "Starts the TCP SSH server daemon (separate process) on the port set in [server].listen_port. For agent-backed auth, start the agent first with 'sshush start'.",
+		Args:    argsNoneOrHelp,
+		RunE:    runServer,
+	}
+	cmd.Flags().StringP("config", "c", "", "path to config file")
+	cmd.AddCommand(newServerStatusCommand())
+	cmd.AddCommand(newServerStopCommand())
+	return cmd
+}
+
+func runServer(cmd *cobra.Command, _ []string) error {
+	if env.Config == nil {
+		return style.NewOutput().Error("config not loaded").AsError()
+	}
+	cfg := *env.Config
+	if cfg.ServerListenPort <= 0 {
+		return style.NewOutput().
+			Error("SSH server is not enabled.").
+			Info("Set [server].listen_port in config (e.g. listen_port = 2222) then run 'sshush server'.").
+			AsError()
+	}
+	if cfg.ServerAuthorizedKeys == "" && !sshushd.CheckAlreadyRunning(cfg.SocketPath) {
+		return style.NewOutput().
+			Error("Agent not running.").
+			Info("Start the agent first with 'sshush start'.").
+			AsError()
+	}
+	configPath, err := runtime.ResolveConfigPath(cmd)
+	if err != nil {
+		return err
+	}
+	if err := sshushd.StartServerDaemon(configPath, int(cfg.ServerListenPort)); err != nil {
+		if err.Error() == "already running" {
+			style.NewOutput().Success("SSH server is already running on port " + fmt.Sprint(cfg.ServerListenPort)).PrintErr()
+			return nil
+		}
+		return style.NewOutput().Error(err.Error()).AsError()
+	}
+	style.NewOutput().Success("SSH server started on port " + fmt.Sprint(cfg.ServerListenPort)).Print()
+	return nil
+}
+
+func newServerStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show SSH server status and test connection",
+		Long:  "Check if the SSH server daemon is running (via pidfile), then test TCP connection to [server].listen_port.",
+		Args:  argsNoneOrHelp,
+		RunE:  runServerStatus,
+	}
+}
+
+func runServerStatus(cmd *cobra.Command, _ []string) error {
+	configPath, err := runtime.ResolveConfigPath(cmd)
+	if err != nil {
+		return err
+	}
+	cfg, err := LoadMergedConfig(configPath, LoadOverrides{})
+	if err != nil {
+		return err
+	}
+	if cfg.ServerListenPort <= 0 {
+		style.NewOutput().
+			Error("SSH server is not enabled ([server].listen_port not set or 0)").
+			Info("Set [server].listen_port in config (e.g. listen_port = 2222) then run 'sshush server'.").
+			Print()
+		return nil
+	}
+
+	pidFilePath := runtime.ServerPidFilePath()
+	var processRunning bool
+	var pid int
+	data, err := os.ReadFile(pidFilePath)
+	if err == nil {
+		pid, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+		if pid > 0 {
+			if p, findErr := os.FindProcess(pid); findErr == nil && p.Signal(syscall.Signal(0)) == nil {
+				processRunning = true
+			}
+		}
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(int(cfg.ServerListenPort))
+	conn, dialErr := net.DialTimeout("tcp", addr, 2*time.Second)
+	if dialErr == nil {
+		conn.Close()
+	}
+
+	out := style.NewOutput()
+	out.Info(fmt.Sprintf("port: %d", cfg.ServerListenPort))
+	if processRunning {
+		out.Info(fmt.Sprintf("process: running (PID %d)", pid))
+	} else {
+		out.Info("process: not running")
+	}
+	if dialErr != nil {
+		out.Info("connection: failed (" + dialErr.Error() + ")")
+		if processRunning {
+			out.Info("(process has pidfile but port not reachable)")
+		}
+	} else {
+		out.Info("connection: ok")
+	}
+	out.Print()
+	return nil
+}
+
+func newServerStopCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the SSH server daemon",
+		Long:  "Stop the TCP SSH server daemon by sending SIGTERM and removing its pidfile.",
+		Args:  argsNoneOrHelp,
+		RunE:  runServerStop,
+	}
+}
+
+func runServerStop(_ *cobra.Command, _ []string) error {
+	pidFilePath := runtime.ServerPidFilePath()
+	if err := sshushd.StopDaemon(pidFilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return style.NewOutput().
+				Error("no pidfile at " + pidFilePath).
+				Info("SSH server may not be running").
+				AsError()
+		}
+		return style.NewOutput().Error(err.Error()).AsError()
+	}
+	style.NewOutput().Success("SSH server stopped").Print()
+	return nil
+}

--- a/internal/server/auth_agent.go
+++ b/internal/server/auth_agent.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"crypto/subtle"
+
+	sshagent "golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh"
+)
+
+// AgentAuth implements AuthKeySource using keys listed by an SSH agent.
+type AgentAuth struct {
+	Agent sshagent.Agent
+}
+
+// Authorized returns true if the given public key is one of the keys in the agent.
+func (a *AgentAuth) Authorized(key ssh.PublicKey) bool {
+	keys, err := a.Agent.List()
+	if err != nil {
+		return false
+	}
+	clientBlob := key.Marshal()
+	for _, k := range keys {
+		if len(k.Blob) == len(clientBlob) && subtle.ConstantTimeCompare(k.Blob, clientBlob) == 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/auth_agent_test.go
+++ b/internal/server/auth_agent_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	sshagent "golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestAgentAuth_Authorized(t *testing.T) {
+	_, priv1, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer1, err := ssh.NewSignerFromKey(priv1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub1 := signer1.PublicKey()
+
+	_, priv2, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer2, err := ssh.NewSignerFromKey(priv2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub2 := signer2.PublicKey()
+
+	keyring := sshagent.NewKeyring()
+	if err := keyring.Add(sshagent.AddedKey{PrivateKey: priv1}); err != nil {
+		t.Fatal(err)
+	}
+
+	auth := &AgentAuth{Agent: keyring}
+
+	if !auth.Authorized(pub1) {
+		t.Error("expected Authorized(pub1) = true (key in agent)")
+	}
+	if auth.Authorized(pub2) {
+		t.Error("expected Authorized(pub2) = false (key not in agent)")
+	}
+}

--- a/internal/server/auth_file.go
+++ b/internal/server/auth_file.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/subtle"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// FileAuth implements AuthKeySource by reading authorized keys from a file (e.g. OpenSSH authorized_keys format).
+// The file is read at construction. Changes to the file require a new FileAuth.
+type FileAuth struct {
+	blobs [][]byte
+}
+
+// NewFileAuth reads the file at path and parses it as authorized_keys (one key per line, ssh.ParseAuthorizedKey).
+// Returns an error if the file cannot be read; invalid lines are skipped.
+func NewFileAuth(path string) (*FileAuth, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var blobs [][]byte
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(line))
+		if err != nil {
+			continue
+		}
+		blobs = append(blobs, pub.Marshal())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return &FileAuth{blobs: blobs}, nil
+}
+
+// Authorized returns true if the given public key matches one of the keys in the file.
+func (f *FileAuth) Authorized(key ssh.PublicKey) bool {
+	clientBlob := key.Marshal()
+	for _, b := range f.blobs {
+		if len(b) == len(clientBlob) && subtle.ConstantTimeCompare(b, clientBlob) == 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/auth_file_test.go
+++ b/internal/server/auth_file_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestFileAuth_Authorized(t *testing.T) {
+	_, priv1, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer1, err := ssh.NewSignerFromKey(priv1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub1 := signer1.PublicKey()
+	line1 := string(ssh.MarshalAuthorizedKey(pub1))
+
+	_, priv2, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer2, err := ssh.NewSignerFromKey(priv2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub2 := signer2.PublicKey()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authorized_keys")
+	if err := os.WriteFile(path, []byte(line1), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	auth, err := NewFileAuth(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !auth.Authorized(pub1) {
+		t.Error("expected Authorized(pub1) = true (key in file)")
+	}
+	if auth.Authorized(pub2) {
+		t.Error("expected Authorized(pub2) = false (key not in file)")
+	}
+}
+
+func TestFileAuth_InvalidFile(t *testing.T) {
+	_, err := NewFileAuth("/nonexistent/path")
+	if err == nil {
+		t.Error("expected error when file does not exist")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io"
+
+	gliderlabs "github.com/gliderlabs/ssh"
+	"golang.org/x/crypto/ssh"
+)
+
+// AuthKeySource provides authorized-key checks for the SSH server.
+// Implementations must use constant-time comparison when comparing keys.
+type AuthKeySource interface {
+	Authorized(key ssh.PublicKey) bool
+}
+
+// Server is a TCP SSH server that authenticates by public key and serves a simple session message.
+// It does not depend on config or CLI; all data is passed via struct fields.
+type Server struct {
+	ListenAddr  string
+	AuthKeys    AuthKeySource
+	HostKeyPath string
+}
+
+// ListenAndServe starts the SSH server on s.ListenAddr. It does not return until the server exits.
+// If HostKeyPath is set, that file is used; otherwise an ephemeral in-memory key is used for this process.
+func (s *Server) ListenAndServe() error {
+	opts := []gliderlabs.Option{
+		gliderlabs.PublicKeyAuth(s.publicKeyAuth),
+	}
+	if s.HostKeyPath != "" {
+		opts = append(opts, gliderlabs.HostKeyFile(s.HostKeyPath))
+	} else {
+		pem, err := generateHostKeyPEM()
+		if err != nil {
+			return fmt.Errorf("generate host key: %w", err)
+		}
+		opts = append(opts, gliderlabs.HostKeyPEM(pem))
+	}
+	return gliderlabs.ListenAndServe(s.ListenAddr, s.handleSession, opts...)
+}
+
+func (s *Server) publicKeyAuth(ctx gliderlabs.Context, key gliderlabs.PublicKey) bool {
+	return s.AuthKeys.Authorized(key)
+}
+
+func (s *Server) handleSession(sess gliderlabs.Session) {
+	io.WriteString(sess, "sshush session (authorized by key)\n")
+}
+
+func generateHostKeyPEM() ([]byte, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(block), nil
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sshagent "golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestServer_ListenAndServe_sessionMessage(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyring := sshagent.NewKeyring()
+	if err := keyring.Add(sshagent.AddedKey{PrivateKey: priv}); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	srv := &Server{
+		ListenAddr:  addr,
+		AuthKeys:    &AgentAuth{Agent: keyring},
+		HostKeyPath: "",
+	}
+	go func() { _ = srv.ListenAndServe() }()
+	time.Sleep(100 * time.Millisecond)
+
+	config := &ssh.ClientConfig{
+		User: "test",
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	conn, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	session, err := conn.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Shell(); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(stdout)
+	session.Close()
+
+	scanner := bufio.NewScanner(bytes.NewReader(buf.Bytes()))
+	if !scanner.Scan() {
+		t.Fatal("expected at least one line")
+	}
+	line := scanner.Text()
+	if line != "sshush session (authorized by key)" {
+		t.Errorf("session output = %q, want %q", line, "sshush session (authorized by key)")
+	}
+}
+
+// TestServer_RejectUnauthorizedKey ensures a client with a key not in the auth source is rejected.
+func TestServer_RejectUnauthorizedKey(t *testing.T) {
+	_, privAuthorized, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signerAuthorized, err := ssh.NewSignerFromKey(privAuthorized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, privUnknown, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signerUnknown, err := ssh.NewSignerFromKey(privUnknown)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyring := sshagent.NewKeyring()
+	if err := keyring.Add(sshagent.AddedKey{PrivateKey: privAuthorized}); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	srv := &Server{
+		ListenAddr:  addr,
+		AuthKeys:    &AgentAuth{Agent: keyring},
+		HostKeyPath: "",
+	}
+	go func() { _ = srv.ListenAndServe() }()
+	time.Sleep(100 * time.Millisecond)
+
+	config := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signerUnknown)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	conn, err := ssh.Dial("tcp", addr, config)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected SSH auth to fail for unauthorized key")
+	}
+	if conn != nil {
+		t.Fatal("conn should be nil on auth failure")
+	}
+	// Sanity: authorized key still works
+	configOK := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signerAuthorized)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	connOK, err := ssh.Dial("tcp", addr, configOK)
+	if err != nil {
+		t.Fatalf("authorized key should connect: %v", err)
+	}
+	connOK.Close()
+}
+
+// TestServer_HostKeyFromFile runs the server with a host key from a temp file and connects.
+func TestServer_HostKeyFromFile(t *testing.T) {
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, clientPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(clientPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring := sshagent.NewKeyring()
+	if err := keyring.Add(sshagent.AddedKey{PrivateKey: clientPriv}); err != nil {
+		t.Fatal(err)
+	}
+
+	block, err := ssh.MarshalPrivateKey(hostPriv, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostKeyFile := filepath.Join(t.TempDir(), "host_key")
+	if err := os.WriteFile(hostKeyFile, pem.EncodeToMemory(block), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	srv := &Server{
+		ListenAddr:  addr,
+		AuthKeys:    &AgentAuth{Agent: keyring},
+		HostKeyPath: hostKeyFile,
+	}
+	go func() { _ = srv.ListenAndServe() }()
+	time.Sleep(100 * time.Millisecond)
+
+	config := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	conn, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("connect with host key file: %v", err)
+	}
+	conn.Close()
+}

--- a/internal/sshushd/daemon.go
+++ b/internal/sshushd/daemon.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/ollykeran/sshush/internal/agent"
 	"github.com/ollykeran/sshush/internal/config"
+	"github.com/ollykeran/sshush/internal/server"
 	"github.com/ollykeran/sshush/internal/utils"
 	"github.com/ollykeran/sshush/internal/vault"
 	sshagent "golang.org/x/crypto/ssh/agent"
@@ -106,6 +108,55 @@ func RunDaemonOnly(cfg config.Config, pidFilePath string) error {
 		return err
 	}
 	return nil
+}
+
+// RunServerOnly runs the TCP SSH server daemon in the current process: detaches, writes pidfile,
+// and runs the server (connecting to the agent socket for auth when [server].authorized_keys is not set).
+// Call only from the sshushd binary when invoked with --server. Removes pidfile on exit.
+func RunServerOnly(cfg config.Config, pidFilePath string) error {
+	if cfg.ServerListenPort <= 0 {
+		return fmt.Errorf("[server].listen_port must be set in config (e.g. listen_port = 2222 under [server])")
+	}
+	port := int(cfg.ServerListenPort)
+	listenAddr := ":" + strconv.Itoa(port)
+
+	var authSource server.AuthKeySource
+	if cfg.ServerAuthorizedKeys != "" {
+		fa, err := server.NewFileAuth(cfg.ServerAuthorizedKeys)
+		if err != nil {
+			return fmt.Errorf("server authorized_keys %s: %w", utils.DisplayPath(cfg.ServerAuthorizedKeys), err)
+		}
+		authSource = fa
+	} else {
+		conn, err := net.Dial("unix", cfg.SocketPath)
+		if err != nil {
+			return fmt.Errorf("agent not running at %s: %w", utils.DisplayPath(cfg.SocketPath), err)
+		}
+		defer conn.Close()
+		authSource = &server.AgentAuth{Agent: sshagent.NewClient(conn)}
+	}
+	if cfg.ServerHostKey != "" {
+		if _, err := os.Stat(cfg.ServerHostKey); err != nil {
+			return fmt.Errorf("server host key %s: %w", utils.DisplayPath(cfg.ServerHostKey), err)
+		}
+	}
+
+	if err := detachProcess(); err != nil {
+		return err
+	}
+	if pidFilePath != "" {
+		if err := os.WriteFile(pidFilePath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644); err != nil {
+			return fmt.Errorf("write pidfile: %w", err)
+		}
+		defer os.Remove(pidFilePath)
+	}
+
+	srv := &server.Server{
+		ListenAddr:  listenAddr,
+		AuthKeys:    authSource,
+		HostKeyPath: cfg.ServerHostKey,
+	}
+	return srv.ListenAndServe()
 }
 
 // WaitForSocket waits until the socket at socketPath is accepting connections or timeout.

--- a/test/e2e/server_test.go
+++ b/test/e2e/server_test.go
@@ -1,0 +1,394 @@
+package e2e
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
+)
+
+// writeE2EConfigWithServer writes a TOML config like writeE2EConfig plus optional [server] fields.
+func writeE2EConfigWithServer(t *testing.T, dir, socketPath, vaultPath string, keyPaths []string, serverPort int, authorizedKeysPath, hostKeyPath string) string {
+	t.Helper()
+	configPath := filepath.Join(dir, "config.toml")
+	var b strings.Builder
+	b.WriteString("[agent]\n")
+	b.WriteString(fmt.Sprintf("socket_path = %q\n", socketPath))
+	if vaultPath != "" {
+		b.WriteString("vault = true\n")
+	} else {
+		b.WriteString("vault = false\n")
+	}
+	if len(keyPaths) > 0 {
+		quoted := make([]string, len(keyPaths))
+		for i, p := range keyPaths {
+			quoted[i] = fmt.Sprintf("%q", p)
+		}
+		b.WriteString("key_paths = [" + strings.Join(quoted, ", ") + "]\n")
+	}
+	if vaultPath != "" {
+		b.WriteString("\n[vault]\n")
+		b.WriteString(fmt.Sprintf("vault_path = %q\n", vaultPath))
+	}
+	if serverPort > 0 || authorizedKeysPath != "" || hostKeyPath != "" {
+		b.WriteString("\n[server]\n")
+		if serverPort > 0 {
+			b.WriteString(fmt.Sprintf("listen_port = %d\n", serverPort))
+		}
+		if authorizedKeysPath != "" {
+			b.WriteString(fmt.Sprintf("authorized_keys = %q\n", authorizedKeysPath))
+		}
+		if hostKeyPath != "" {
+			b.WriteString(fmt.Sprintf("host_key = %q\n", hostKeyPath))
+		}
+	}
+	if err := os.WriteFile(configPath, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func TestE2E_ServerStartStop(t *testing.T) {
+	dir := e2eWorkDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	vaultPath := filepath.Join(dir, "vault.json")
+	serverPort := 22402
+
+	binDir := buildBins(t)
+	configPath := writeE2EConfigWithServer(t, dir, socketPath, vaultPath, nil, serverPort, "", "")
+	runtimeDir := dir
+
+	// Vault init
+	if err := os.WriteFile(filepath.Join(dir, "init_stdin.txt"), []byte("e2epass\ne2epass\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	initStdin, err := os.Open(filepath.Join(dir, "init_stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer initStdin.Close()
+	_, _, code := runSSHush(t, binDir, configPath, runtimeDir, initStdin, "vault", "init", "--no-recovery")
+	if code != 0 {
+		t.Fatalf("vault init: exit %d", code)
+	}
+
+	// Start agent
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, strings.NewReader(e2ePassphrase), "start")
+	if code != 0 {
+		t.Fatalf("start: exit %d", code)
+	}
+
+	// Start server
+	stdout, stderr, code := runSSHush(t, binDir, configPath, runtimeDir, nil, "server")
+	if code != 0 {
+		t.Fatalf("server start: exit %d\nstderr: %s", code, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "started") && !strings.Contains(combined, "22402") {
+		t.Errorf("server output should contain started or port; got stdout: %q stderr: %q", stdout, stderr)
+	}
+
+	// Port should be listening
+	addr := fmt.Sprintf("127.0.0.1:%d", serverPort)
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("server port not listening: %v", err)
+	}
+	conn.Close()
+
+	// Stop server
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "server", "stop")
+	if code != 0 {
+		t.Fatalf("server stop: exit %d", code)
+	}
+
+	// Port should be closed
+	for i := 0; i < 20; i++ {
+		if c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond); err != nil {
+			break
+		} else {
+			c.Close()
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond); err == nil {
+		conn.Close()
+		t.Error("server port should be closed after server stop")
+	}
+
+	// Stop agent
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "stop")
+}
+
+func TestE2E_ServerConnectAgentAuth(t *testing.T) {
+	dir := e2eWorkDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	vaultPath := filepath.Join(dir, "vault.json")
+	serverPort := 22403
+
+	binDir := buildBins(t)
+	configPath := writeE2EConfigWithServer(t, dir, socketPath, vaultPath, nil, serverPort, "", "")
+	runtimeDir := dir
+
+	// Vault init
+	initStdin := strings.NewReader("e2epass\ne2epass\n")
+	_, _, code := runSSHush(t, binDir, configPath, runtimeDir, initStdin, "vault", "init", "--no-recovery")
+	if code != 0 {
+		t.Fatalf("vault init: exit %d", code)
+	}
+	// Start agent
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, strings.NewReader(e2ePassphrase), "start")
+	if code != 0 {
+		t.Fatalf("start: exit %d", code)
+	}
+	// Add key
+	keyPath := writeE2ETestKey(t, dir, "id_ed25519", "e2e-server-key")
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "add", keyPath)
+	if code != 0 {
+		t.Fatalf("add: exit %d", code)
+	}
+	// Start server
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "server")
+	if code != 0 {
+		t.Fatalf("server: exit %d", code)
+	}
+
+	// Connect with agent auth
+	agentConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial agent: %v", err)
+	}
+	defer agentConn.Close()
+	signers := sshagent.NewClient(agentConn)
+	clientConfig := &ssh.ClientConfig{
+		User: "e2e",
+		Auth: []ssh.AuthMethod{ssh.PublicKeysCallback(signers.Signers)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+	sshConn, err := ssh.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", serverPort), clientConfig)
+	if err != nil {
+		t.Fatalf("SSH dial: %v", err)
+	}
+	defer sshConn.Close()
+	session, err := sshConn.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := session.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+	var out bytes.Buffer
+	out.ReadFrom(stdout)
+	session.Close()
+	if !bytes.Contains(out.Bytes(), []byte("sshush session (authorized by key)")) {
+		t.Errorf("expected session message; got: %s", out.String())
+	}
+
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "server", "stop")
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "stop")
+}
+
+func TestE2E_ServerFileAuth(t *testing.T) {
+	dir := e2eWorkDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	keyPath := writeE2ETestKey(t, dir, "id_ed25519", "fileauth-key")
+	serverPort := 22404
+	authorizedKeysPath := filepath.Join(dir, "authorized_keys")
+
+	pubBytes, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(authorizedKeysPath, pubBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := buildBins(t)
+	configPath := writeE2EConfigWithServer(t, dir, socketPath, "", []string{keyPath}, serverPort, authorizedKeysPath, "")
+	runtimeDir := dir
+
+	// Start agent (so sshush server has a socket to connect to for config; actually for file auth we don't need agent)
+	_, _, code := runSSHush(t, binDir, configPath, runtimeDir, nil, "start")
+	if code != 0 {
+		t.Fatalf("start: exit %d", code)
+	}
+	// Start server with file auth
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "server")
+	if code != 0 {
+		t.Fatalf("server: exit %d", code)
+	}
+
+	signer, err := readSignerFromFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientConfig := &ssh.ClientConfig{
+		User:            "e2e",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+	sshConn, err := ssh.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", serverPort), clientConfig)
+	if err != nil {
+		t.Fatalf("SSH dial: %v", err)
+	}
+	defer sshConn.Close()
+	session, err := sshConn.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+	stdout, _ := session.StdoutPipe()
+	_ = session.Shell()
+	var out bytes.Buffer
+	out.ReadFrom(stdout)
+	session.Close()
+	if !bytes.Contains(out.Bytes(), []byte("sshush session (authorized by key)")) {
+		t.Errorf("expected session message; got: %s", out.String())
+	}
+
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "server", "stop")
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "stop")
+}
+
+func readSignerFromFile(path string) (ssh.Signer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.ParsePrivateKey(data)
+}
+
+func TestE2E_ServerHostKeyFile(t *testing.T) {
+	dir := e2eWorkDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	keyPath := writeE2ETestKey(t, dir, "id_ed25519", "hostkey-key")
+	serverPort := 22405
+	hostKeyPath := filepath.Join(dir, "host_ed25519")
+
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(hostPriv, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hostKeyPath, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := buildBins(t)
+	configPath := writeE2EConfigWithServer(t, dir, socketPath, "", []string{keyPath}, serverPort, "", hostKeyPath)
+	runtimeDir := dir
+
+	_, _, code := runSSHush(t, binDir, configPath, runtimeDir, nil, "start")
+	if code != 0 {
+		t.Fatalf("start: exit %d", code)
+	}
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "server")
+	if code != 0 {
+		t.Fatalf("server: exit %d", code)
+	}
+
+	signer, err := readSignerFromFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientConfig := &ssh.ClientConfig{
+		User:            "e2e",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+	sshConn, err := ssh.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", serverPort), clientConfig)
+	if err != nil {
+		t.Fatalf("SSH dial: %v", err)
+	}
+	sshConn.Close()
+
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "server", "stop")
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "stop")
+}
+
+func TestE2E_ServerAddKeyThenConnect(t *testing.T) {
+	dir := e2eWorkDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	vaultPath := filepath.Join(dir, "vault.json")
+	serverPort := 22406
+
+	binDir := buildBins(t)
+	configPath := writeE2EConfigWithServer(t, dir, socketPath, vaultPath, nil, serverPort, "", "")
+	runtimeDir := dir
+
+	initStdin := strings.NewReader("e2epass\ne2epass\n")
+	_, _, code := runSSHush(t, binDir, configPath, runtimeDir, initStdin, "vault", "init", "--no-recovery")
+	if code != 0 {
+		t.Fatalf("vault init: exit %d", code)
+	}
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, strings.NewReader(e2ePassphrase), "start")
+	if code != 0 {
+		t.Fatalf("start: exit %d", code)
+	}
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "server")
+	if code != 0 {
+		t.Fatalf("server: exit %d", code)
+	}
+
+	// Add key after server is already running (agent has key, server uses agent auth)
+	keyPath := writeE2ETestKey(t, dir, "id_ed25519", "added-later")
+	_, _, code = runSSHush(t, binDir, configPath, runtimeDir, nil, "add", keyPath)
+	if code != 0 {
+		t.Fatalf("add: exit %d", code)
+	}
+
+	agentConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial agent: %v", err)
+	}
+	defer agentConn.Close()
+	signers := sshagent.NewClient(agentConn)
+	clientConfig := &ssh.ClientConfig{
+		User: "e2e",
+		Auth: []ssh.AuthMethod{ssh.PublicKeysCallback(signers.Signers)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+	sshConn, err := ssh.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", serverPort), clientConfig)
+	if err != nil {
+		t.Fatalf("SSH dial: %v", err)
+	}
+	defer sshConn.Close()
+	session, err := sshConn.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+	stdout, _ := session.StdoutPipe()
+	_ = session.Shell()
+	var out bytes.Buffer
+	out.ReadFrom(stdout)
+	session.Close()
+	if !bytes.Contains(out.Bytes(), []byte("sshush session (authorized by key)")) {
+		t.Errorf("expected session message after add key; got: %s", out.String())
+	}
+
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "server", "stop")
+	runSSHush(t, binDir, configPath, runtimeDir, nil, "stop")
+}


### PR DESCRIPTION
## Summary
- Add `internal/server` (TCP SSH, file or agent auth)
- Wire `sshush server` CLI and `sshushd --server`
- E2E coverage; optional GitLab mirror workflow

## Stack
- Bases on #49 (`split/vault-mode`)
- After #49 merges, retarget to `master`

## Test plan
- [x] `go test ./internal/server/ ./test/e2e/ -race`
- [x] Start agent, `sshush server start`, SSH to listen port with agent key