### PR TITLE
chore: README polish and release/version helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # sshush
 
-An SSH agent with a styled CLI and TUI. Drop-in replacement for `ssh-agent`. Manages keys via a Unix socket, compatible with OpenSSH (`ssh`, `ssh-add`, etc.).
+OpenSSH compatible agent over a Unix socket (`SSH_AUTH_SOCK`, same agent protocol as `ssh-agent`) with a TUI, themes, and a config file. I wanted the agent to stay out of the way for normal `ssh` use but still be easy to inspect and reload from dotfiles, without piling on shell wrapper scripts. Optional passphrase vault stores derived keys in one file.
+
+## Compared to `ssh-agent`
+
+Stock agent is minimal: good for some workflows, easy to make invisible. sshush adds a `config.toml` with `sshush reload` to match the live agent to that file, plus `sshush tui` and a styled CLI. Optional vault and lock/unlock for encrypted at-rest key material in one place, instead of only relying on file permissions. Everything else: Unix socket, `ssh-add` / `ssh` work as usual.
+
+**Tradeoff:** more surface area than a stock agent, so keep an eye on [issues](https://github.com/ollykeran/sshush/issues) if something surprises you on your OS or shell.
+
+## Demo
+
+[Asciinema recording](https://asciinema.org/a/917054) (click through for the player)
 
 ## Quick Start
 
@@ -8,58 +18,51 @@ An SSH agent with a styled CLI and TUI. Drop-in replacement for `ssh-agent`. Man
 eval $(sshush)
 ```
 
-That starts the daemon (if needed), loads keys from config, and exports `SSH_AUTH_SOCK`. Add it to `.zshrc`, `.bashrc`, or `.bash_profile` for persistent setup. See [Setup Guide](docs/setup.md) for details.
+Starts the daemon if needed, loads keys from config, sets `SSH_AUTH_SOCK`. For shell rc and edge cases, see [Setup guide](docs/setup.md).
 
 ## Features
 
-- **Agent**: Start, stop, list keys, add, remove. Uses a Unix socket; works with OpenSSH.
-- **Create/Edit/Export**: Generate keys (`create`), edit comments (`edit`), export public keys (`export`).
-- **TUI**: Interactive terminal UI to manage keys, generate, edit, and export. Run `sshush tui`.
+- **Agent**: start/stop, add/remove, list, reload from config, Unix socket (`SSH_AUTH_SOCK`).
+- **Keys**: create, edit comment, find, export public key.
+- **TUI**: `sshush tui` for interactive key management.
 - **Vault**: Encrypted on-disk key store with lock/unlock and recovery. See [docs/vault.md](docs/vault.md).
 - **SSH server**: Optional TCP SSH server (`sshush server`). See [Config Reference](docs/config.md) `[server]` section.
-- **Reload**: `sshush reload` reconciles the agent to the config file. Keys not in config are removed; keys in config are added. If you change `[agent].socket_path`, the daemon restarts.
-- **Config auto-setup**: On first run, if no config exists, sshush creates the default config under `$XDG_CONFIG_HOME/sshush/` (or `~/.config/sshush/`) with discovered keys and a stable `socket_path` (`$XDG_RUNTIME_DIR/sshush.sock` when set, otherwise `~/.config/sshush/sshush.sock`). You can write the same default file anytime with `sshush generate config` (optional path; use `--force` to overwrite).
+- **Reload**: `sshush reload` drops keys not in `config.toml` and adds new ones; changing `[agent].socket_path` can restart the daemon.
+- **First run**: with no config, writes defaults under `$XDG_CONFIG_HOME/sshush` (or `~/.config/sshush`), discovers keys, picks a stable socket path. Regenerate the default file with `sshush generate config` (`--force` to overwrite).
 
-## Commands
+## Common commands
 
+| | |
+| --- | --- |
+| `eval $(sshush)` or `sshush start` | start daemon, export `SSH_AUTH_SOCK` |
+| `sshush stop` | stop daemon |
+| `sshush list` / `add` / `remove` | manage loaded keys |
+| `sshush reload` | match agent to `config.toml` |
+| `sshush tui` | interactive UI |
+| `sshush create` / `edit` / `export` / `find` | key file operations |
+| `sshush vault …` / `lock` / `unlock` | optional encrypted vault (see [docs/vault.md](docs/vault.md)) |
+| `sshush server` | optional TCP SSH server |
+| `sshush theme` / `completion` / `version` | theming, shell completion, build info |
 
-| Sub Command      | Description                               | Example                                   |
-| ---------------- | ----------------------------------------- | ----------------------------------------- |
-| (none) / `start` | Start daemon, export `SSH_AUTH_SOCK`      | `eval $(sshush)`                          |
-| `stop`           | Stop the daemon                           | `sshush stop`                             |
-| `list`           | List keys in the agent                    | `sshush list`                             |
-| `add`            | Add key(s) to the agent                   | `sshush add ~/.ssh/id_ed25519`            |
-| `remove`         | Remove key(s) by path or comment          | `sshush remove id_ed25519`                |
-| `reload`         | Reconcile agent to config file            | `sshush reload`                           |
-| `create`         | Generate a new keypair                    | `sshush create rsa 2048 -o ~/.ssh/id_rsa` |
-| `edit`           | Edit key comment                          | `sshush edit ~/.ssh/id_ed25519`           |
-| `export`         | Export public key                         | `sshush export ~/.ssh/id_ed25519`         |
-| `find`           | Find private keys (defaults: cwd, ~/.ssh) | `sshush find` or `sshush find /path`      |
-| `generate config`| Write default `config.toml` (optional path) | `sshush generate config`                |
-| `tui`            | Start the TUI                             | `sshush tui`                              |
-| `theme`          | Show or set colour theme                  | `sshush theme show`, `sshush theme list`, `sshush theme set dracula` |
-| `completion`     | Shell completion script                   | `sshush completion bash`                  |
-| `version`        | Print version                             | `sshush version`                          |
+For every subcommand and flag, `sshush --help` and `sshush <subcommand> --help`.
 
-
-Config: `$XDG_CONFIG_HOME/sshush/config.toml` or `~/.config/sshush/config.toml` (override with `-c` / `$SSHUSH_CONFIG`). See [Config Reference](docs/config.md).
+**Config file:** `$XDG_CONFIG_HOME/sshush/config.toml` or `~/.config/sshush/config.toml`, or override with `-c` / `SSHUSH_CONFIG`. Reference: [Config](docs/config.md).
 
 **Upgrading from older releases:** config layout changed from flat keys to `[agent]` / `[vault]` / `[server]` tables. See [Migration from flat TOML](docs/config.md#migration-from-flat-toml-breaking) before merging this branch into your setup.
 
 ## Installation
 
-### From releases
+`sshush` and `sshushd` need to be visible together: either a directory on your `PATH`, or run them with explicit paths (same idea as a normal `ssh-agent` + client setup).
 
-Download from [GitHub Releases](https://github.com/ollykeran/sshush/releases):
+### Releases
 
-| Package | Install |
-|---------|---------|
-| **Debian/Ubuntu** (`.deb`) | `sudo dpkg -i sshush-*-amd64.deb` |
-| **RHEL/Fedora** (`.rpm`) | `sudo rpm -i sshush-*-amd64.rpm` |
-| **Arch Linux** (`.pkg.tar.zst`) | `sudo pacman -U sshush-*-amd64.pkg.tar.zst` |
-| **Linux binary tarball** | Extract `sshush` and `sshushd` from `sshush-*-linux-amd64.tar.gz`, place in `PATH` |
-| **macOS Apple Silicon** | Extract from `sshush-*-darwin-arm64.tar.gz`, place in `PATH` |
-| **macOS Intel** | Extract from `sshush-*-darwin-amd64.tar.gz`, place in `PATH` |
+[GitHub Releases](https://github.com/ollykeran/sshush/releases): `.deb`, `.rpm`, Arch `.pkg.tar.zst`, `tar.gz` (Linux and macOS arm/amd on the release page). Release archives ship both binaries; install or unpack as usual.
+
+| Package | |
+| --- | --- |
+| **Debian/Ubuntu** | `sudo dpkg -i sshush-*-amd64.deb` |
+| **RHEL/Fedora** | `sudo rpm -i sshush-*-amd64.rpm` |
+| **Arch** | `sudo pacman -U sshush-*-amd64.pkg.tar.zst` |
 
 ### From source
 
@@ -68,31 +71,32 @@ go install github.com/ollykeran/sshush/cmd/sshush@latest
 go install github.com/ollykeran/sshush/cmd/sshushd@latest
 ```
 
-Both binaries must be in `PATH`.
+Binaries go to `$(go env GOBIN)` (or `GOPATH/bin`).
+
+Clone (optional): `git clone https://github.com/ollykeran/sshush.git`
+
+## Security
+
+`sshushd` speaks the same agent protocol as `ssh-agent` over a local socket; private keys live in the agent process. Report vulnerabilities as described in [SECURITY.md](SECURITY.md) (not via public issues).
 
 ## Docs
 
-- [Setup Guide](docs/setup.md) – eval, config creation, shell rc files
-- [Config Reference](docs/config.md) – options, reload behavior, flat TOML migration
-- [Vault](docs/vault.md) – encrypted vault mode, recovery, commands
-- [TUI Architecture](docs/tui.md) – TUI structure and internals
-- [Architecture](docs/architecture.md) – package layout
-- [Godoc Guide](docs/godoc-guide.md) – adding godoc comments
-- [pkg.go.dev](https://pkg.go.dev/github.com/ollykeran/sshush) – API documentation
+- [Setup](docs/setup.md) – shell, eval, config path
+- [Config](docs/config.md) – options, reload, flat TOML migration
+- [Vault](docs/vault.md) – optional vault
+- [TUI](docs/tui.md) – TUI structure
+- [Architecture](docs/architecture.md) – packages
+- [Godoc guide](docs/godoc-guide.md) – exported API comments
+- [pkg.go.dev](https://pkg.go.dev/github.com/ollykeran/sshush) – API
 
-### Developer docs
-
-- [Contributing](CONTRIBUTING.md) – how to contribute
-- [Internal Boundary Report](docs/internal-boundary-report.md) – package call graph (auto-generated)
+**Developers:** [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Internal boundary report](docs/internal-boundary-report.md) (auto-generated)
 
 ## Build
 
-Go 1.26+:
+Go 1.26+, [`just`](https://github.com/casey/just) optional but recommended.
 
 ```sh
 just build
 ```
 
-Produces `sshush` (CLI) and `sshushd` (daemon) in `build/`. Both must be in `PATH` or the same directory.
-
-For macOS binaries in `build/sshush` and `build/sshushd`, use `just build-mac` (native arch on Darwin, or set `MAC_ARCH=amd64` when cross-compiling from Linux). Release tarballs use `just build-darwin arm64` and `just build-darwin amd64` under `build/darwin-arm64/` and `build/darwin-amd64/`; `just package` builds Linux artifacts plus both Darwin tarballs.
+Outputs `build/sshush` and `build/sshushd`. From the repo, run e.g. `./build/sshush` and `./build/sshushd` or install the artifacts the same way you do other static binaries. macOS: `just build-mac`. Release layout and packaging: `just package`, `just build-darwin arm64`, etc. (see [justfile](justfile)).

--- a/cmd/sshushd/main.go
+++ b/cmd/sshushd/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	stdruntime "runtime"
 
 	"github.com/ollykeran/sshush/internal/config"
 	"github.com/ollykeran/sshush/internal/runtime"
@@ -20,7 +19,7 @@ func main() {
 	serverMode := flag.Bool("server", false, "run TCP SSH server daemon only")
 	flag.Parse()
 	if *showVersion {
-		fmt.Printf("sshushd %s (%s)\n", version.Version, stdruntime.Version())
+		fmt.Println(version.Line("sshushd"))
 		os.Exit(0)
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	stdruntime "runtime"
 
 	"github.com/ollykeran/sshush/internal/agent"
 	"github.com/ollykeran/sshush/internal/config"
@@ -154,7 +153,7 @@ func NewRootCommand() *cobra.Command {
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if cmd.Flags().Changed("version") {
-				fmt.Printf("sshush %s (%s)\n", version.Version, stdruntime.Version())
+				fmt.Println(version.Line("sshush"))
 				os.Exit(0)
 			}
 			if isGenerateConfigCmd(cmd) {

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/ollykeran/sshush/internal/version"
 	"github.com/spf13/cobra"
@@ -16,7 +15,7 @@ func newVersionCommand() *cobra.Command {
 		Short:   "Print the sshush version",
 		Args:    argsNoneOrHelp,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("sshush %s (%s)\n", version.Version, runtime.Version())
+			fmt.Println(version.Line("sshush"))
 		},
 	}
 }

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -178,7 +178,7 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.running {
 				state = "running"
 			}
-			s.sk.UpdateWidgetValue("sshushd", state)
+			s.sk.UpdateWidgetValue(daemonStatusWidgetID(), state)
 		}
 		return s, nil
 
@@ -225,7 +225,7 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.status = msg.text
 		s.statusErr = msg.isErr
 		if s.sk != nil {
-			s.sk.UpdateWidgetValue("sshushd", msg.text)
+			s.sk.UpdateWidgetValue(daemonStatusWidgetID(), msg.text)
 		}
 		if !msg.isErr {
 			return s, tea.Batch(

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -5,7 +5,13 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/ollykeran/sshush/internal/theme"
+	"github.com/ollykeran/sshush/internal/version"
 )
+
+// daemonStatusWidgetID is the footer left label for daemon state (e.g. "sshushd v1.2.3").
+func daemonStatusWidgetID() string {
+	return "sshushd v" + version.Version
+}
 
 // ButtonFlashDoneMsg is sent when a button press flash animation completes.
 type ButtonFlashDoneMsg struct{}
@@ -65,6 +71,6 @@ func NewTUI(configPath, socketPath string, t theme.Theme, agentBackendMode strin
 	s.AddPage("create", "Create", NewCreateScreen(s))
 	s.AddPage("edit", "Edit", NewEditScreen(s, socketPath))
 	s.AddPage("export", "Export", NewExportScreen(s, socketPath))
-	s.AddWidget("sshushd", "stopped")
+	s.AddWidget(daemonStatusWidgetID(), "stopped")
 	return s
 }

--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -1,2 +1,3 @@
-// Package version holds the sshush version string, set at build time via ldflags.
+// Package version holds the sshush version string, set at build time via ldflags,
+// and formats version lines with Go runtime, OS, and architecture.
 package version

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,13 @@
 package version
 
+import (
+	"fmt"
+	"runtime"
+)
+
 var Version = "dev"
+
+// Line returns "<name> <version> (<goversion> <os>/<arch>)".
+func Line(name string) string {
+	return fmt.Sprintf("%s %s (%s %s/%s)", name, Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}

--- a/justfile
+++ b/justfile
@@ -194,22 +194,31 @@ check-artifacts ver="dev":
     echo "$pass passed, $fail failed"
     [ "$fail" -eq 0 ]
 
-# Create a GitHub release (creates tag, triggers CI to build packages)
-release ver:
-    gh release create v{{ ver }} --generate-notes --latest
+# Create a GitHub release (tag at branch tip if missing; triggers CI on tag push)
+release ver branch:
+    gh release create "v{{ ver }}" --generate-notes --latest --target "{{ branch }}"
 
 # List jobs in the release workflow (via act)
 act-list:
     act -l push -e .github/events/push-tag.json -W .github/workflows/release.yml
 
-# Run the release workflow locally (via act); Release step is skipped
-act-release ver:
+# Write .github/events/push-tag.json: tag ref + `after` = branch tip SHA (sets github.sha for act; --defaultbranch alone does not).
+[private]
+act-push-tag-json ver branch:
     #!/usr/bin/env bash
-    echo '{"ref": "refs/tags/v{{ ver }}"}' > .github/events/push-tag.json
-    act push -e .github/events/push-tag.json -W .github/workflows/release.yml
+    set -euo pipefail
+    br="{{ branch }}"
+    ver="{{ ver }}"
+    if git show-ref --verify --quiet "refs/heads/$br"; then
+      sha=$(git rev-parse "refs/heads/$br")
+    elif git show-ref --verify --quiet "refs/remotes/origin/$br"; then
+      sha=$(git rev-parse "refs/remotes/origin/$br")
+    else
+      echo "act-push-tag-json: unknown branch '$br' (need refs/heads/$br or refs/remotes/origin/$br)" >&2
+      exit 1
+    fi
+    printf '{"ref":"refs/tags/v%s","before":"0000000000000000000000000000000000000000","after":"%s"}\n' "$ver" "$sha" > .github/events/push-tag.json
 
-# Dry-run the release workflow locally (via act)
-act-release-dry ver:
-    #!/usr/bin/env bash
-    echo '{"ref": "refs/tags/v{{ ver }}"}' > .github/events/push-tag.json
-    act -n push -e .github/events/push-tag.json -W .github/workflows/release.yml
+# Run the release workflow locally (via act); Release step is skipped
+act-release ver branch: (act-push-tag-json ver branch)
+    act push -e .github/events/push-tag.json -W .github/workflows/release.yml --defaultbranch "{{ branch }}"


### PR DESCRIPTION
## Summary
- Cherry-pick develop doc/release polish (`b92350e`) onto current `master`
- README: compare-to-ssh-agent, demo link, clearer commands; keep vault/server/migration; **no GUI**
- Centralize `version.Line`; release/`act` just recipes take a target branch

## Test plan
- [ ] `go test ./internal/cli/ ./cmd/...`
- [ ] `sshush version` / `sshushd -version` format looks right
- [ ] Skim README for missing/broken links (no `docs/gui.md`)