### PR TITLE
feat(agent): store filepath in key object for edit and reload support

### DIFF
--- a/internal/agent/keys.go
+++ b/internal/agent/keys.go
@@ -7,12 +7,49 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/ollykeran/sshush/internal/openssh"
 	"github.com/ollykeran/sshush/internal/style"
 	ssh "golang.org/x/crypto/ssh"
 	sshagent "golang.org/x/crypto/ssh/agent"
 )
+
+// filepathRegistry maps key fingerprints to their original file paths on disk.
+// Used by the edit command and other operations that need to locate the source file.
+var filepathRegistry sync.Map
+
+// RegisterFilepath records the file path for a key fingerprint.
+func RegisterFilepath(fingerprint, path string) {
+	filepathRegistry.Store(fingerprint, path)
+}
+
+// GetFilepath returns the file path for a key fingerprint, or empty string if not found.
+func GetFilepath(fingerprint string) string {
+	if v, ok := filepathRegistry.Load(fingerprint); ok {
+		return v.(string)
+	}
+	return ""
+}
+
+// ResolveFilepath attempts to find the source file path for a key by fingerprint.
+// For non-vault agents, it falls back to parsing each path in cfgPaths to match.
+func ResolveFilepath(fingerprint string, cfgPaths []string) string {
+	if fp := GetFilepath(fingerprint); fp != "" {
+		return fp
+	}
+	for _, path := range cfgPaths {
+		pubKey, _, _, err := ParseKeyFromPath(path)
+		if err != nil {
+			continue
+		}
+		if ssh.FingerprintSHA256(pubKey) == fingerprint {
+			RegisterFilepath(fingerprint, path)
+			return path
+		}
+	}
+	return ""
+}
 
 // ParseKeyFromPath reads a private key file and returns the public key,
 // comment, and raw private key without adding to any keyring.
@@ -54,11 +91,14 @@ func ParseKeyFromPath(path string) (ssh.PublicKey, string, interface{}, error) {
 }
 
 // AddKeyFromPath reads a private key from path and adds it to the keyring.
+// The fingerprint-to-filepath mapping is registered for later lookup.
 func AddKeyFromPath(keyring sshagent.Agent, path string) error {
-	_, comment, key, err := ParseKeyFromPath(path)
+	pubKey, comment, key, err := ParseKeyFromPath(path)
 	if err != nil {
 		return err
 	}
+	fp := ssh.FingerprintSHA256(pubKey)
+	RegisterFilepath(fp, path)
 	return keyring.Add(sshagent.AddedKey{PrivateKey: key, Comment: comment})
 }
 

--- a/internal/agent/keys_test.go
+++ b/internal/agent/keys_test.go
@@ -102,3 +102,83 @@ func TestLoadKeys_skipsBadPaths(t *testing.T) {
 		t.Fatalf("want 1 key after skipping bad path, got %d", len(keys))
 	}
 }
+
+func TestAddKeyFromPath_registersFilepath(t *testing.T) {
+	keyPEM := mustMarshalKey(t, "reg-test")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(path, keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	keyring := sshagent.NewKeyring()
+	if err := AddKeyFromPath(keyring, path); err != nil {
+		t.Fatalf("AddKeyFromPath: %v", err)
+	}
+
+	keys, err := keyring.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(keys))
+	}
+
+	pub, err := ssh.ParsePublicKey(keys[0].Blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := ssh.FingerprintSHA256(pub)
+	got := GetFilepath(fp)
+	if got != path {
+		t.Fatalf("GetFilepath(%s) = %q, want %q", fp, got, path)
+	}
+}
+
+func TestRegisterAndGetFilepath(t *testing.T) {
+	fp := "SHA256:test-fingerprint"
+	path := "/home/user/.ssh/id_ed25519"
+
+	if got := GetFilepath(fp); got != "" {
+		t.Fatalf("GetFilepath before register: got %q, want empty", got)
+	}
+
+	RegisterFilepath(fp, path)
+	if got := GetFilepath(fp); got != path {
+		t.Fatalf("GetFilepath after register: got %q, want %q", got, path)
+	}
+}
+
+func TestResolveFilepath_fallbackToCfgPaths(t *testing.T) {
+	keyPEM := mustMarshalKey(t, "cfg-test")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(path, keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the fingerprint
+	pub, _, _, err := ParseKeyFromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := ssh.FingerprintSHA256(pub)
+
+	// Registry is empty — should fall back to cfgPaths
+	got := ResolveFilepath(fp, []string{path})
+	if got != path {
+		t.Fatalf("ResolveFilepath = %q, want %q", got, path)
+	}
+
+	// Should now be cached in registry
+	if cached := GetFilepath(fp); cached != path {
+		t.Fatalf("GetFilepath after resolve = %q, want %q", cached, path)
+	}
+}
+
+func TestResolveFilepath_notFound(t *testing.T) {
+	got := ResolveFilepath("SHA256:nonexistent", nil)
+	if got != "" {
+		t.Fatalf("ResolveFilepath for unknown = %q, want empty", got)
+	}
+}

--- a/internal/cli/agent_integration_test.go
+++ b/internal/cli/agent_integration_test.go
@@ -117,7 +117,7 @@ func TestAgentIntegration_EditThenAdd(t *testing.T) {
 		t.Fatalf("runCreate: %v", err)
 	}
 
-	if err := runEdit(keyPath, "", "after-edit", false, ""); err != nil {
+	if err := runEdit(keyPath, "", "after-edit", false, "", ""); err != nil {
 		t.Fatalf("runEdit: %v", err)
 	}
 

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -4,16 +4,22 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/ollykeran/sshush/internal/agent"
 	"github.com/ollykeran/sshush/internal/editcomment"
 	"github.com/ollykeran/sshush/internal/keys"
 	"github.com/ollykeran/sshush/internal/runtime"
+	"github.com/ollykeran/sshush/internal/sshushd"
 	"github.com/ollykeran/sshush/internal/style"
 	"github.com/ollykeran/sshush/internal/utils"
+	"github.com/ollykeran/sshush/internal/vault"
 	"github.com/spf13/cobra"
 	ssh "golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
 )
 
 func newEditCommand() *cobra.Command {
@@ -21,36 +27,214 @@ func newEditCommand() *cobra.Command {
 	var commentFlag string
 	var copyFlag bool
 	var outputFlag string
+	var filepathFlag string
 
 	cmd := &cobra.Command{
-		Use:   "edit <private-key-filepath>",
-		Short: "Edit comment on a private key file",
-		Long:  "Edit an SSH private key comment, overwrite the key file or copy to a new file.",
+		Use:   "edit <private-key-filepath | fingerprint | comment>",
+		Short: "Edit comment on a private key",
+		Long: "Edit an SSH private key comment, overwrite the key file or copy to a new file. " +
+			"The argument can be a filepath, a SHA256 fingerprint, or a comment to look up from the running agent.",
 		Example: `sshush edit ~/.ssh/id_ed25519 --comment 'new-comment'
-sshush edit ~/.ssh/id_rsa`,
+sshush edit ~/.ssh/id_rsa
+sshush edit SHA256:abc... --comment 'renamed'
+sshush edit my-key-comment --comment 'updated'`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				cmd.Help()
 				cmd.SilenceUsage = true
-				return style.NewOutput().Error("exactly one private key filepath is required").AsError()
+				return style.NewOutput().Error("exactly one key selector is required").AsError()
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runEdit(args[0], editorFlag, commentFlag, copyFlag, outputFlag)
+			return runEdit(args[0], editorFlag, commentFlag, copyFlag, outputFlag, filepathFlag)
 		},
 	}
 	cmd.Flags().StringVarP(&editorFlag, "editor", "e", "", "editor command (default $EDITOR, fallback vim,nano,vi)")
 	cmd.Flags().StringVarP(&commentFlag, "comment", "C", "", "new key comment (skip editor)")
 	cmd.Flags().BoolVar(&copyFlag, "copy", false, "write edited key to a new file (requires -o/--output)")
 	cmd.Flags().StringVarP(&outputFlag, "output", "o", "", "destination path when using --copy")
+	cmd.Flags().StringVar(&filepathFlag, "filepath", "", "explicit source key file path (overrides auto-resolution)")
 	return cmd
 }
 
-func runEdit(privateKeyPath, editorFlag, commentFlag string, copyFlag bool, outputFlag string) error {
-	privateKeyPath = utils.ExpandHomeDirectory(privateKeyPath)
-	if _, err := os.Stat(privateKeyPath); err != nil {
-		return style.NewOutput().Error(fmt.Sprintf("key file not found: %s", utils.DisplayPath(privateKeyPath))).AsError()
+// resolveEditPath resolves the argument to a private key filepath.
+// It tries: 1) explicit --filepath flag, 2) as a filepath, 3) as a fingerprint in the agent,
+// 4) as a comment in the agent, 5) fallback to config KeyPaths.
+func resolveEditPath(arg, filepathFlag string) (string, error) {
+	// Explicit override takes highest priority
+	if strings.TrimSpace(filepathFlag) != "" {
+		path := utils.ExpandHomeDirectory(filepathFlag)
+		if _, err := os.Stat(path); err != nil {
+			return "", fmt.Errorf("key file not found: %s", utils.DisplayPath(path))
+		}
+		return path, nil
+	}
+
+	// Try as filepath directly
+	path := utils.ExpandHomeDirectory(arg)
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+
+	// Try as fingerprint or comment from the agent
+	socketPath, err := getSocketPath()
+	if err == nil && sshushd.CheckAlreadyRunning(socketPath) {
+		agentKeys, listErr := agent.ListKeysFromSocket(socketPath)
+		if listErr == nil {
+			// Try fingerprint match
+			for _, k := range agentKeys {
+				pub, parseErr := ssh.ParsePublicKey(k.Blob)
+				if parseErr != nil {
+					continue
+				}
+				fp := ssh.FingerprintSHA256(pub)
+				if fp == arg {
+					if fp := agent.GetFilepath(fp); fp != "" {
+						return fp, nil
+					}
+					// Fallback: check config KeyPaths
+					if cfgPath := resolveFromConfig(fp); cfgPath != "" {
+						return cfgPath, nil
+					}
+					return "", fmt.Errorf("fingerprint %s found in agent but source file path is unknown; use --filepath to specify", arg)
+				}
+			}
+			// Try comment match
+			for _, k := range agentKeys {
+				if k.Comment == arg {
+					pub, parseErr := ssh.ParsePublicKey(k.Blob)
+					if parseErr != nil {
+						continue
+					}
+					fp := ssh.FingerprintSHA256(pub)
+					if fp := agent.GetFilepath(fp); fp != "" {
+						return fp, nil
+					}
+					// Fallback: check config KeyPaths
+					if cfgPath := resolveFromConfig(fp); cfgPath != "" {
+						return cfgPath, nil
+					}
+					return "", fmt.Errorf("comment %q found in agent but source file path is unknown; use --filepath to specify", arg)
+				}
+			}
+		}
+	}
+
+	// Last resort: check config KeyPaths by parsing each file
+	if env.Config != nil {
+		for _, cfgPath := range env.Config.KeyPaths {
+			pub, _, _, parseErr := agent.ParseKeyFromPath(cfgPath)
+			if parseErr != nil {
+				continue
+			}
+			if ssh.FingerprintSHA256(pub) == arg || filepath.Base(cfgPath) == arg {
+				return cfgPath, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("key not found: %s", arg)
+}
+
+// resolveFromConfig tries to find a key file in the config KeyPaths by fingerprint.
+func resolveFromConfig(fingerprint string) string {
+	if env.Config == nil {
+		return ""
+	}
+	for _, cfgPath := range env.Config.KeyPaths {
+		pub, _, _, err := agent.ParseKeyFromPath(cfgPath)
+		if err != nil {
+			continue
+		}
+		if ssh.FingerprintSHA256(pub) == fingerprint {
+			agent.RegisterFilepath(fingerprint, cfgPath)
+			return cfgPath
+		}
+	}
+	return ""
+}
+
+// isKeyLoadedInAgent checks if a key with the given fingerprint is loaded in the running agent.
+func isKeyLoadedInAgent(socketPath, fingerprint string) bool {
+	if !sshushd.CheckAlreadyRunning(socketPath) {
+		return false
+	}
+	agentKeys, err := agent.ListKeysFromSocket(socketPath)
+	if err != nil {
+		return false
+	}
+	for _, k := range agentKeys {
+		pub, err := ssh.ParsePublicKey(k.Blob)
+		if err != nil {
+			continue
+		}
+		if ssh.FingerprintSHA256(pub) == fingerprint {
+			return true
+		}
+	}
+	return false
+}
+
+// reloadKeyInAgent removes the old key and re-adds it after an edit.
+// For vault mode, uses add-key-opts; for standard mode, removes and re-adds.
+func reloadKeyInAgent(socketPath, privateKeyPath, newComment string) error {
+	if !sshushd.CheckAlreadyRunning(socketPath) {
+		return nil
+	}
+	mode, live := agent.LiveBackendMode(socketPath)
+	if !live {
+		return nil
+	}
+
+	// Find and remove the old key
+	agentKeys, err := agent.ListKeysFromSocket(socketPath)
+	if err != nil {
+		return fmt.Errorf("list keys: %w", err)
+	}
+	conn, dialErr := net.Dial("unix", socketPath)
+	if dialErr != nil {
+		return fmt.Errorf("connect to agent: %w", dialErr)
+	}
+	defer conn.Close()
+	client := sshagent.NewClient(conn)
+
+	for _, k := range agentKeys {
+		pub, parseErr := ssh.ParsePublicKey(k.Blob)
+		if parseErr != nil {
+			continue
+		}
+		fp := ssh.FingerprintSHA256(pub)
+		existingFP := ""
+		if _, statErr := os.Stat(privateKeyPath); statErr == nil {
+			pubKey, _, _, err := agent.ParseKeyFromPath(privateKeyPath)
+			if err == nil {
+				existingFP = ssh.FingerprintSHA256(pubKey)
+			}
+		}
+		if existingFP != "" && fp == existingFP {
+			_ = client.Remove(pub)
+			break
+		}
+	}
+
+	// Re-add the key with updated comment
+	if mode == "vault" {
+		if err := vault.AddPrivateKeyFileToSocket(socketPath, privateKeyPath, true); err != nil {
+			return fmt.Errorf("reload key in vault: %w", err)
+		}
+	} else {
+		if err := agent.AddKeyToSocketFromPath(socketPath, privateKeyPath); err != nil {
+			return fmt.Errorf("reload key in agent: %w", err)
+		}
+	}
+	return nil
+}
+
+func runEdit(arg, editorFlag, commentFlag string, copyFlag bool, outputFlag, filepathFlag string) error {
+	privateKeyPath, err := resolveEditPath(arg, filepathFlag)
+	if err != nil {
+		return style.NewOutput().Error(err.Error()).AsError()
 	}
 
 	if copyFlag && strings.TrimSpace(outputFlag) == "" {
@@ -67,6 +251,8 @@ func runEdit(privateKeyPath, editorFlag, commentFlag string, copyFlag bool, outp
 		}
 		return style.NewOutput().Error(err.Error()).AsError()
 	}
+
+	fingerprint := ssh.FingerprintSHA256(signer.PublicKey())
 
 	comment := commentFlag
 	if strings.TrimSpace(comment) == "" {
@@ -114,12 +300,23 @@ func runEdit(privateKeyPath, editorFlag, commentFlag string, copyFlag bool, outp
 
 	out := style.NewOutput().
 		Success("updated key comment").
-		Info("fingerprint: " + ssh.FingerprintSHA256(signer.PublicKey())).
+		Info("fingerprint: " + fingerprint).
 		Info("path: " + utils.DisplayPath(destPath))
 
 	if copyFlag {
 		out.Info("source: " + utils.DisplayPath(privateKeyPath))
 	}
+
+	// Reload key in agent if it's loaded
+	socketPath, sockErr := getSocketPath()
+	if sockErr == nil && isKeyLoadedInAgent(socketPath, fingerprint) {
+		if reloadErr := reloadKeyInAgent(socketPath, privateKeyPath, comment); reloadErr != nil {
+			out.Warn("key updated on disk but agent reload failed: " + reloadErr.Error())
+		} else {
+			out.Success("reloaded key in agent")
+		}
+	}
+
 	out.Print()
 	return nil
 }

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ollykeran/sshush/internal/editcomment"
 	"github.com/ollykeran/sshush/internal/openssh"
 	"github.com/ollykeran/sshush/internal/runtime"
+	ssh "golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
 )
 
 func TestRunEdit_commentFlag(t *testing.T) {
@@ -18,7 +20,7 @@ func TestRunEdit_commentFlag(t *testing.T) {
 	dir := t.TempDir()
 	privPath := writeTestKey(t, dir, "id_ed25519", "old-comment")
 
-	err := runEdit(privPath, "", "new-comment", false, "")
+	err := runEdit(privPath, "", "new-comment", false, "", "")
 	if err != nil {
 		t.Fatalf("runEdit: %v", err)
 	}
@@ -33,7 +35,7 @@ func TestRunEdit_copyToNewPath(t *testing.T) {
 	privPath := writeTestKey(t, dir, "id_ed25519", "original")
 	copyPath := filepath.Join(dir, "copy_key")
 
-	err := runEdit(privPath, "", "copied-comment", true, copyPath)
+	err := runEdit(privPath, "", "copied-comment", true, copyPath, "")
 	if err != nil {
 		t.Fatalf("runEdit: %v", err)
 	}
@@ -54,7 +56,7 @@ func TestRunEdit_copyWithoutOutput(t *testing.T) {
 	dir := t.TempDir()
 	privPath := writeTestKey(t, dir, "id_ed25519", "test")
 
-	err := runEdit(privPath, "", "x", true, "")
+	err := runEdit(privPath, "", "x", true, "", "")
 	if err == nil {
 		t.Fatal("expected error when --copy without --output")
 	}
@@ -65,7 +67,7 @@ func TestRunEdit_outputWithoutCopy(t *testing.T) {
 	dir := t.TempDir()
 	privPath := writeTestKey(t, dir, "id_ed25519", "test")
 
-	err := runEdit(privPath, "", "x", false, "/tmp/somewhere")
+	err := runEdit(privPath, "", "x", false, "/tmp/somewhere", "")
 	if err == nil {
 		t.Fatal("expected error when --output without --copy")
 	}
@@ -73,7 +75,7 @@ func TestRunEdit_outputWithoutCopy(t *testing.T) {
 
 func TestRunEdit_missingFile(t *testing.T) {
 	t.Parallel()
-	err := runEdit(filepath.Join(t.TempDir(), "nonexistent"), "", "x", false, "")
+	err := runEdit(filepath.Join(t.TempDir(), "nonexistent"), "", "x", false, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing key file")
 	}
@@ -85,7 +87,7 @@ func TestRunEdit_notOpenSSHKey(t *testing.T) {
 	badPath := filepath.Join(dir, "bad_key")
 	os.WriteFile(badPath, []byte("not a key"), 0o600)
 
-	err := runEdit(badPath, "", "x", false, "")
+	err := runEdit(badPath, "", "x", false, "", "")
 	if err == nil {
 		t.Fatal("expected error for non-OpenSSH key")
 	}
@@ -98,7 +100,7 @@ func TestRunEdit_emptyComment(t *testing.T) {
 	// Use a fake editor that writes whitespace-only content
 	editorPath := writeFakeEditor(t, dir, "empty-editor.sh", "   ")
 
-	err := runEdit(privPath, editorPath, "", false, "")
+	err := runEdit(privPath, editorPath, "", false, "", "")
 	if err == nil {
 		t.Fatal("expected error for empty comment")
 	}
@@ -109,7 +111,7 @@ func TestRunEdit_pubFileUpdated(t *testing.T) {
 	dir := t.TempDir()
 	privPath := writeTestKey(t, dir, "id_ed25519", "before")
 
-	err := runEdit(privPath, "", "after", false, "")
+	err := runEdit(privPath, "", "after", false, "", "")
 	if err != nil {
 		t.Fatalf("runEdit: %v", err)
 	}
@@ -123,7 +125,7 @@ func TestRunEdit_noPubFile(t *testing.T) {
 	privPath := writeTestKey(t, dir, "id_ed25519", "only-priv")
 	os.Remove(privPath + ".pub")
 
-	err := runEdit(privPath, "", "updated", false, "")
+	err := runEdit(privPath, "", "updated", false, "", "")
 	if err != nil {
 		t.Fatalf("runEdit: %v", err)
 	}
@@ -209,7 +211,7 @@ func TestRunEdit_editorFlow(t *testing.T) {
 	editorPath := writeFakeEditor(t, dir, "editor.sh", "editor-comment")
 
 	// empty commentFlag triggers editor path
-	err := runEdit(privPath, editorPath, "", false, "")
+	err := runEdit(privPath, editorPath, "", false, "", "")
 	if err != nil {
 		t.Fatalf("runEdit with editor: %v", err)
 	}
@@ -223,7 +225,7 @@ func TestRunEdit_editorFailsReportsError(t *testing.T) {
 	privPath := writeTestKey(t, dir, "id_ed25519", "old-comment")
 	editorPath := writeFailingEditor(t, dir, "bad-editor.sh")
 
-	err := runEdit(privPath, editorPath, "", false, "")
+	err := runEdit(privPath, editorPath, "", false, "", "")
 	if err == nil {
 		t.Fatal("expected error when editor fails")
 	}
@@ -235,7 +237,7 @@ func TestRunEdit_exitWithoutSaving_keyNotModified(t *testing.T) {
 	privPath := writeTestKey(t, dir, "id_ed25519", "original-comment")
 	editorPath := writeNoOpEditor(t, dir, "noop-editor.sh")
 
-	err := runEdit(privPath, editorPath, "", false, "")
+	err := runEdit(privPath, editorPath, "", false, "", "")
 	if err != nil {
 		t.Fatalf("runEdit with no-save should succeed with no error: %v", err)
 	}
@@ -269,5 +271,93 @@ func assertPubKeyComment(t *testing.T, pubPath, wantComment string) {
 	line := strings.TrimSpace(string(data))
 	if !strings.HasSuffix(line, wantComment) {
 		t.Errorf("pub key line should end with %q: %s", wantComment, line)
+	}
+}
+
+// --- resolveEditPath tests ---
+
+func TestResolveEditPath_directFilepath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	privPath := writeTestKey(t, dir, "id_ed25519", "test")
+
+	got, err := resolveEditPath(privPath, "")
+	if err != nil {
+		t.Fatalf("resolveEditPath: %v", err)
+	}
+	if got != privPath {
+		t.Fatalf("got %q, want %q", got, privPath)
+	}
+}
+
+func TestResolveEditPath_filepathFlagOverride(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	privPath := writeTestKey(t, dir, "id_ed25519", "test")
+
+	// Even with a bogus argument, --filepath should win
+	got, err := resolveEditPath("nonexistent-arg", privPath)
+	if err != nil {
+		t.Fatalf("resolveEditPath with --filepath: %v", err)
+	}
+	if got != privPath {
+		t.Fatalf("got %q, want %q", got, privPath)
+	}
+}
+
+func TestResolveEditPath_filepathFlagNotFound(t *testing.T) {
+	t.Parallel()
+	_, err := resolveEditPath("anything", "/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error for nonexistent --filepath")
+	}
+}
+
+func TestResolveEditPath_notFound(t *testing.T) {
+	t.Parallel()
+	_, err := resolveEditPath("completely-unknown-key", "")
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+}
+
+func TestResolveEditPath_fingerprintFromAgent(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv
+	socketPath, client := startTestAgent(t)
+
+	dir := t.TempDir()
+	privPath := writeTestKey(t, dir, "id_ed25519", "agent-key")
+
+	// Load key into agent
+	keyData, err := os.ReadFile(privPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawKey, err := ssh.ParseRawPrivateKey(keyData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Add(sshagent.AddedKey{PrivateKey: rawKey, Comment: "agent-key"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get fingerprint
+	signer, err := ssh.NewSignerFromKey(rawKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := ssh.FingerprintSHA256(signer.PublicKey())
+
+	// Point SSH_AUTH_SOCK to our test agent so resolveEditPath can reach it
+	t.Setenv("SSH_AUTH_SOCK", socketPath)
+
+	// The fingerprint won't be in the registry (added via client.Add, not AddKeyFromPath),
+	// and the key isn't in cfg.KeyPaths, so this should error gracefully.
+	_, err = resolveEditPath(fp, "")
+	if err == nil {
+		t.Fatal("expected error for fingerprint not in registry or config")
+	}
+	if !strings.Contains(err.Error(), "use --filepath") {
+		t.Fatalf("error should hint about --filepath, got: %v", err)
 	}
 }

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -241,7 +241,7 @@ func runVaultList(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := style.NewOutput()
-	out.Add(style.Highlight(fmt.Sprintf("%-70s  %-6s  %-8s  %-20s  %s", "FINGERPRINT", "LOADED", "AUTOLOAD", "COMMENT", "TYPE")))
+	out.Add(style.Highlight(fmt.Sprintf("%-70s  %-6s  %-8s  %-20s  %-10s  %s", "FINGERPRINT", "LOADED", "AUTOLOAD", "COMMENT", "TYPE", "FILEPATH")))
 	maxTypeLen := 0
 	for _, id := range identities {
 		if len(id.KeyType) > maxTypeLen {
@@ -265,7 +265,11 @@ func runVaultList(cmd *cobra.Command, _ []string) error {
 		if len(comment) > 20 {
 			comment = comment[:17] + "..."
 		}
-		out.Add(style.Highlight(fmt.Sprintf("%-70s  %-6s  %-8s  %-20s  %-*s", id.Fingerprint, loaded, autoload, comment, maxTypeLen, id.KeyType)))
+		filepath := id.Filepath
+		if filepath == "" {
+			filepath = "-"
+		}
+		out.Add(style.Highlight(fmt.Sprintf("%-70s  %-6s  %-8s  %-20s  %-*s  %s", id.Fingerprint, loaded, autoload, comment, maxTypeLen, id.KeyType, filepath)))
 	}
 	out.PrintTo(os.Stdout)
 	return nil

--- a/internal/keys/keys_test.go
+++ b/internal/keys/keys_test.go
@@ -145,6 +145,26 @@ func TestLoadKeyMaterialAndSaveWithComment(t *testing.T) {
 	}
 }
 
+func TestLoadKeyMaterial_setsFilepath(t *testing.T) {
+	dir := t.TempDir()
+	priv, pub, err := Generate("ed25519", 0, "filepath-test")
+	if err != nil {
+		t.Fatalf("Generate(): %v", err)
+	}
+	if err := SavePair(dir, "id_ed25519", priv, pub); err != nil {
+		t.Fatalf("SavePair(): %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "id_ed25519")
+	parsed, _, _, err := LoadKeyMaterial(keyPath)
+	if err != nil {
+		t.Fatalf("LoadKeyMaterial(): %v", err)
+	}
+	if parsed.Filepath != keyPath {
+		t.Fatalf("parsed.Filepath = %q, want %q", parsed.Filepath, keyPath)
+	}
+}
+
 func TestFormatPublicKey(t *testing.T) {
 	priv, _, err := Generate("ed25519", 0, "fmt")
 	if err != nil {

--- a/internal/keys/load.go
+++ b/internal/keys/load.go
@@ -38,5 +38,7 @@ func LoadKeyMaterial(path string) (*openssh.ParsedKey, interface{}, ssh.Signer, 
 		return nil, nil, nil, fmt.Errorf("keys: create signer for %s: %w", path, err)
 	}
 
+	parsed.Filepath = path
+
 	return parsed, rawKey, signer, nil
 }

--- a/internal/openssh/parse.go
+++ b/internal/openssh/parse.go
@@ -25,6 +25,7 @@ type ParsedKey struct {
 	Comment    string
 	PublicKey  []byte // SSH wire format public key (e.g. for ssh.ParsePublicKey)
 	PrivateKey []byte // PEM-encoded private key
+	Filepath   string // original file path on disk (populated by callers)
 }
 
 // ParsePrivateKeyBlob parses unencrypted OpenSSH private key data.

--- a/internal/vault/agent.go
+++ b/internal/vault/agent.go
@@ -70,12 +70,12 @@ func (a *VaultAgent) List() ([]*sshagent.Key, error) {
 // Add encrypts the private key and adds it to the store with autoload=false,
 // and adds the fingerprint to the session set so the key is visible until restart.
 func (a *VaultAgent) Add(key sshagent.AddedKey) error {
-	return a.addKeyWithAutoload(key, false)
+	return a.addKeyWithAutoload(key, false, "")
 }
 
 // addKeyWithAutoload adds the key with the given autoload.
 // When autoload is false, the fingerprint is added to sessionAutoload0 so the key is visible until restart.
-func (a *VaultAgent) addKeyWithAutoload(key sshagent.AddedKey, autoload bool) error {
+func (a *VaultAgent) addKeyWithAutoload(key sshagent.AddedKey, autoload bool, keyFilepath string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	signer, err := ssh.NewSignerFromKey(key.PrivateKey)
@@ -102,6 +102,7 @@ func (a *VaultAgent) addKeyWithAutoload(key sshagent.AddedKey, autoload bool) er
 		PublicKey:     pubBlob,
 		EncryptedBlob: encrypted,
 		Comment:       key.Comment,
+		Filepath:      keyFilepath,
 		Autoload:      autoload,
 	}
 	if err := a.store.AddOrReplaceIdentity(id); err != nil {
@@ -326,26 +327,53 @@ func (a *VaultAgent) Extension(extensionType string, contents []byte) ([]byte, e
 		if len(contents) < 5 {
 			return nil, fmt.Errorf("vault: add-key-opts: payload too short (%d bytes)", len(contents))
 		}
-		pemLen := binary.BigEndian.Uint32(contents[:4])
-		if int(pemLen) > len(contents)-5 {
-			return nil, fmt.Errorf("vault: add-key-opts: PEM length %d exceeds payload", pemLen)
+		// Version detection: old format starts with 4-byte PEM length (first byte 0x00 for typical keys);
+		// new format (v1) starts with version byte 0x01.
+		var pemData []byte
+		var autoload bool
+		var keyFilepath string
+		if contents[0] == 1 && len(contents) >= 10 {
+			// Version 1: [1-byte version][4-byte PEM len][PEM][1-byte autoload][4-byte filepath len][filepath]
+			pemLen := int(binary.BigEndian.Uint32(contents[1:5]))
+			if 5+pemLen > len(contents) {
+				return nil, fmt.Errorf("vault: add-key-opts: PEM length %d exceeds payload", pemLen)
+			}
+			pemData = contents[5 : 5+pemLen]
+			autoloadByte := contents[5+pemLen]
+			if autoloadByte != 0 && autoloadByte != 1 {
+				return nil, fmt.Errorf("vault: add-key-opts: invalid autoload byte %d", autoloadByte)
+			}
+			autoload = autoloadByte == 1
+			fpOffset := 5 + pemLen + 1
+			if fpOffset+4 <= len(contents) {
+				fpLen := int(binary.BigEndian.Uint32(contents[fpOffset : fpOffset+4]))
+				if fpOffset+4+fpLen <= len(contents) {
+					keyFilepath = string(contents[fpOffset+4 : fpOffset+4+fpLen])
+				}
+			}
+		} else {
+			// Legacy format: [4-byte PEM len][PEM][1-byte autoload]
+			pemLen := int(binary.BigEndian.Uint32(contents[:4]))
+			if pemLen > len(contents)-5 {
+				return nil, fmt.Errorf("vault: add-key-opts: PEM length %d exceeds payload", pemLen)
+			}
+			pemData = contents[4 : 4+pemLen]
+			autoloadByte := contents[4+pemLen]
+			if autoloadByte != 0 && autoloadByte != 1 {
+				return nil, fmt.Errorf("vault: add-key-opts: invalid autoload byte %d", autoloadByte)
+			}
+			autoload = autoloadByte == 1
 		}
-		pem := contents[4 : 4+pemLen]
-		autoloadByte := contents[4+pemLen]
-		autoload := autoloadByte == 1
-		if autoloadByte != 0 && autoloadByte != 1 {
-			return nil, fmt.Errorf("vault: add-key-opts: invalid autoload byte %d", autoloadByte)
-		}
-		key, err := ssh.ParseRawPrivateKey(pem)
+		key, err := ssh.ParseRawPrivateKey(pemData)
 		if err != nil {
 			return nil, fmt.Errorf("vault: add-key-opts: parse PEM: %w", err)
 		}
 		comment := ""
-		if parsed, err := openssh.ParsePrivateKeyBlob(pem); err == nil && parsed.Comment != "" {
+		if parsed, err := openssh.ParsePrivateKeyBlob(pemData); err == nil && parsed.Comment != "" {
 			comment = parsed.Comment
 		}
 		addedKey := sshagent.AddedKey{PrivateKey: key, Comment: comment}
-		if err := a.addKeyWithAutoload(addedKey, autoload); err != nil {
+		if err := a.addKeyWithAutoload(addedKey, autoload, keyFilepath); err != nil {
 			return nil, fmt.Errorf("vault: add-key-opts: %w", err)
 		}
 		return []byte("ok"), nil

--- a/internal/vault/agent_test.go
+++ b/internal/vault/agent_test.go
@@ -487,7 +487,7 @@ func TestAutoload_ListFiltersAfterRestart(t *testing.T) {
 	if err := va.Add(sshagent.AddedKey{PrivateKey: privA, Comment: "no-autoload"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: privB, Comment: "autoload"}, true); err != nil {
+	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: privB, Comment: "autoload"}, true, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -605,7 +605,7 @@ func TestExtension_VaultSessionLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, priv, _ := ed25519.GenerateKey(rand.Reader)
-	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: priv, Comment: "noload"}, false); err != nil {
+	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: priv, Comment: "noload"}, false, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -637,7 +637,7 @@ func TestExtension_VaultSessionLoad(t *testing.T) {
 
 	// No-op for autoload identity
 	_, privB, _ := ed25519.GenerateKey(rand.Reader)
-	if err := va2.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: privB, Comment: "autoloaded"}, true); err != nil {
+	if err := va2.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: privB, Comment: "autoloaded"}, true, ""); err != nil {
 		t.Fatal(err)
 	}
 	signerB, _ := ssh.NewSignerFromKey(privB)
@@ -664,7 +664,7 @@ func TestExtension_VaultSetAutoload(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, priv, _ := ed25519.GenerateKey(rand.Reader)
-	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: priv, Comment: "toggle"}, false); err != nil {
+	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: priv, Comment: "toggle"}, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	signer, _ := ssh.NewSignerFromKey(priv)
@@ -695,5 +695,68 @@ func TestExtension_VaultSetAutoload(t *testing.T) {
 	keys3, _ := va3.List()
 	if len(keys3) != 0 {
 		t.Fatalf("after set autoload off: want 0 keys at restart, got %d", len(keys3))
+	}
+}
+
+func TestAddKeyWithAutoload_storesFilepath(t *testing.T) {
+	dir := t.TempDir()
+	vaultPath := filepath.Join(dir, "vault.json")
+	store, err := Open(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passphrase := []byte("filepath-test")
+	if err := Init(store, passphrase); err != nil {
+		t.Fatal(err)
+	}
+
+	va := NewVaultAgent(store)
+	if err := va.Unlock(passphrase); err != nil {
+		t.Fatal(err)
+	}
+
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	keyFilepath := "/home/user/.ssh/id_ed25519"
+	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: priv, Comment: "with-path"}, true, keyFilepath); err != nil {
+		t.Fatal(err)
+	}
+
+	ids := store.AllIdentities()
+	if len(ids) != 1 {
+		t.Fatalf("want 1 identity, got %d", len(ids))
+	}
+	if ids[0].Filepath != keyFilepath {
+		t.Fatalf("Identity.Filepath = %q, want %q", ids[0].Filepath, keyFilepath)
+	}
+}
+
+func TestAddKeyWithAutoload_emptyFilepath(t *testing.T) {
+	dir := t.TempDir()
+	vaultPath := filepath.Join(dir, "vault.json")
+	store, err := Open(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passphrase := []byte("no-path-test")
+	if err := Init(store, passphrase); err != nil {
+		t.Fatal(err)
+	}
+
+	va := NewVaultAgent(store)
+	if err := va.Unlock(passphrase); err != nil {
+		t.Fatal(err)
+	}
+
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	if err := va.addKeyWithAutoload(sshagent.AddedKey{PrivateKey: priv, Comment: "no-path"}, false, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	ids := store.AllIdentities()
+	if len(ids) != 1 {
+		t.Fatalf("want 1 identity, got %d", len(ids))
+	}
+	if ids[0].Filepath != "" {
+		t.Fatalf("Identity.Filepath = %q, want empty", ids[0].Filepath)
 	}
 }

--- a/internal/vault/list.go
+++ b/internal/vault/list.go
@@ -10,6 +10,7 @@ type IdentityInfo struct {
 	Comment     string
 	KeyType     string
 	Autoload    bool
+	Filepath    string
 }
 
 // ListIdentities returns all identities in the vault with metadata.
@@ -27,6 +28,7 @@ func ListIdentities(store *VaultStore) ([]IdentityInfo, error) {
 			Comment:     id.Comment,
 			KeyType:     keyType,
 			Autoload:    id.Autoload,
+			Filepath:    id.Filepath,
 		})
 	}
 	return out, nil

--- a/internal/vault/payload.go
+++ b/internal/vault/payload.go
@@ -19,17 +19,25 @@ func BuildSetAutoloadPayload(fingerprint string, autoload bool) []byte {
 }
 
 // BuildAddKeyOptsPayload builds the extension payload for add-key-opts from a key file path.
-// Payload: 4-byte big-endian PEM length, PEM bytes, 1 byte autoload (0 or 1).
+// Format (version 1): 1-byte version (0x01), 4-byte big-endian PEM length, PEM bytes,
+// 1 byte autoload (0 or 1), 4-byte big-endian filepath length, filepath UTF-8 bytes.
 func BuildAddKeyOptsPayload(path string, autoload bool) ([]byte, error) {
-	pem, err := os.ReadFile(path)
+	pemData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("vault: read key file %s: %w", path, err)
 	}
-	payload := make([]byte, 4+len(pem)+1)
-	binary.BigEndian.PutUint32(payload[:4], uint32(len(pem)))
-	copy(payload[4:], pem)
+	fpBytes := []byte(path)
+	payload := make([]byte, 1+4+len(pemData)+1+4+len(fpBytes))
+	payload[0] = 1 // version 1: includes filepath
+	binary.BigEndian.PutUint32(payload[1:5], uint32(len(pemData)))
+	copy(payload[5:], pemData)
+	autoloadByte := byte(0)
 	if autoload {
-		payload[4+len(pem)] = 1
+		autoloadByte = 1
 	}
+	payload[5+len(pemData)] = autoloadByte
+	filepathOffset := 5 + len(pemData) + 1
+	binary.BigEndian.PutUint32(payload[filepathOffset:filepathOffset+4], uint32(len(fpBytes)))
+	copy(payload[filepathOffset+4:], fpBytes)
 	return payload, nil
 }

--- a/internal/vault/payload_test.go
+++ b/internal/vault/payload_test.go
@@ -24,9 +24,47 @@ func TestBuildAddKeyOptsPayload_autoloadByte(t *testing.T) {
 		if err != nil {
 			t.Fatalf("autoload=%v: %v", tc.autoload, err)
 		}
-		pemLen := int(binary.BigEndian.Uint32(payload[:4]))
-		if got := payload[4+pemLen]; got != tc.wantTail {
+		// v1 format: [1-byte version][4-byte PEM len][PEM][1-byte autoload][4-byte fp len][filepath]
+		if payload[0] != 1 {
+			t.Fatalf("version byte: got %d want 1", payload[0])
+		}
+		pemLen := int(binary.BigEndian.Uint32(payload[1:5]))
+		if got := payload[5+pemLen]; got != tc.wantTail {
 			t.Fatalf("autoload=%v: tail byte got %d want %d", tc.autoload, got, tc.wantTail)
 		}
+	}
+}
+
+func TestBuildAddKeyOptsPayload_filepathRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "id_ed25519")
+	keyData := []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nfake-key-data\n-----END OPENSSH PRIVATE KEY-----")
+	if err := os.WriteFile(p, keyData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := BuildAddKeyOptsPayload(p, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse the v1 payload
+	if payload[0] != 1 {
+		t.Fatalf("version byte: got %d want 1", payload[0])
+	}
+	pemLen := int(binary.BigEndian.Uint32(payload[1:5]))
+	pemData := payload[5 : 5+pemLen]
+	if string(pemData) != string(keyData) {
+		t.Fatalf("PEM data mismatch: got %q, want %q", pemData, keyData)
+	}
+	autoloadByte := payload[5+pemLen]
+	if autoloadByte != 1 {
+		t.Fatalf("autoload byte: got %d, want 1", autoloadByte)
+	}
+	fpOffset := 5 + pemLen + 1
+	fpLen := int(binary.BigEndian.Uint32(payload[fpOffset : fpOffset+4]))
+	filepath := string(payload[fpOffset+4 : fpOffset+4+fpLen])
+	if filepath != p {
+		t.Fatalf("filepath in payload: got %q, want %q", filepath, p)
 	}
 }


### PR DESCRIPTION
Add Filepath field to ParsedKey and Identity structs so the original source file path is tracked alongside each key. This enables editing keys while the agent is running and reloading state after save.

- Add fingerprint-to-filepath registry (sync.Map) in agent/keys.go
- Register filepath in AddKeyFromPath and resolve from config fallback
- Extend vault add-key-opts payload to v1 with filepath (backward compat)
- Store Identity.Filepath in vault agent on key add
- Show filepath column in vault list output
- Edit command now accepts comment/fingerprint (not just filepath)
- Edit command reloads key in agent after save (remove + re-add)
- Add --filepath flag for explicit override when resolution fails
- Fallback: config KeyPaths scan for pre-existing keys without path
- Tests for registry, payload round-trip, vault filepath storage, resolveEditPath fallbacks, and --filepath flag