### PR TITLE
test(sshushd): add unit tests for core daemon functions

### DIFF
--- a/internal/sshushd/control_test.go
+++ b/internal/sshushd/control_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -78,5 +79,101 @@ func TestStopDaemon_removesPidfile(t *testing.T) {
 	}
 	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
 		t.Errorf("pidfile should be removed after StopDaemon")
+	}
+}
+
+func TestStartServerDaemon_pidFileRunning(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "sshush-server.pid")
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	cmd := exec.Command("sh", "-c", "sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start sleep process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := filepath.Join(dir, "config.toml")
+	body := "[agent]\nsocket_path = \"" + dir + "/sock\"\nvault = false\nkey_paths = []\n\n[server]\nlisten_port = " + strconv.Itoa(port) + "\n"
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = StartServerDaemon(configPath, port)
+	if err == nil {
+		t.Fatal("expected error when pidfile has running process")
+	}
+	if !strings.Contains(err.Error(), "server already running on port "+strconv.Itoa(port)) {
+		t.Errorf("expected 'server already running on port %d', got %q", port, err.Error())
+	}
+}
+
+func TestStartDaemon_alreadyRunning(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "daemon.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	err = StartDaemon("", socketPath)
+	if err == nil {
+		t.Fatal("expected error when daemon already running")
+	}
+	if !strings.Contains(err.Error(), "daemon already running") {
+		t.Errorf("expected 'daemon already running' in error, got %q", err.Error())
+	}
+}
+
+func TestStartDaemon_binaryNotFound(t *testing.T) {
+	t.Setenv("PATH", "")
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "daemon.sock")
+
+	err := StartDaemon("", socketPath)
+	if err == nil {
+		t.Fatal("expected error when binary not found")
+	}
+	if !strings.Contains(err.Error(), "binary not found") {
+		t.Errorf("expected 'binary not found' in error, got %q", err.Error())
+	}
+}
+
+func TestReloadDaemon_startFails(t *testing.T) {
+	t.Setenv("PATH", "")
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "daemon.sock")
+	pidPath := filepath.Join(dir, "nonexistent.pid")
+
+	err := ReloadDaemon("", socketPath, pidPath)
+	if err == nil {
+		t.Fatal("expected error when reload fails")
+	}
+	if !strings.Contains(err.Error(), "reload failed") {
+		t.Errorf("expected 'reload failed' in error, got %q", err.Error())
 	}
 }

--- a/internal/sshushd/daemon_test.go
+++ b/internal/sshushd/daemon_test.go
@@ -1,0 +1,193 @@
+package sshushd
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	ssh "golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
+)
+
+func writeTestKey(t *testing.T, dir, filename, comment string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, comment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := pem.EncodeToMemory(block)
+	privPath := filepath.Join(dir, filename)
+	if err := os.WriteFile(privPath, privPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return privPath
+}
+
+func unixSocketTempDir(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return t.TempDir()
+	}
+	dir, err := os.MkdirTemp("/tmp", "sshushd-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func TestRunAgent_withKeys(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	keyPath := writeTestKey(t, dir, "test_key", "test-key")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunAgent(ctx, socketPath, []string{keyPath}, "")
+	}()
+
+	if !WaitForSocket(socketPath, 50, 20*time.Millisecond) {
+		t.Fatal("agent socket did not become ready")
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial agent socket: %v", err)
+	}
+	defer conn.Close()
+
+	client := sshagent.NewClient(conn)
+	keys, err := client.List()
+	if err != nil {
+		t.Fatalf("agent list: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+	if keys[0].Comment != "test-key" {
+		t.Errorf("expected comment 'test-key', got %q", keys[0].Comment)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && !strings.Contains(err.Error(), "closed network connection") {
+			t.Fatalf("RunAgent returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunAgent did not exit after context cancel")
+	}
+}
+
+func TestRunAgent_contextCancel(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunAgent(ctx, socketPath, nil, "")
+	}()
+
+	if !WaitForSocket(socketPath, 50, 20*time.Millisecond) {
+		t.Fatal("agent socket did not become ready")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && !strings.Contains(err.Error(), "closed network connection") {
+			t.Fatalf("RunAgent returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunAgent did not exit after context cancel")
+	}
+}
+
+func TestRunAgent_alreadyRunning(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = RunAgent(ctx, socketPath, nil, "")
+	if err == nil {
+		t.Fatal("expected error when socket already in use")
+	}
+}
+
+func TestRunAgent_vaultPathMissing(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+	vaultPath := filepath.Join(dir, "nonexistent.vault")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunAgent(ctx, socketPath, nil, vaultPath)
+	}()
+
+	if !WaitForSocket(socketPath, 50, 20*time.Millisecond) {
+		t.Fatal("agent socket did not become ready")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && !strings.Contains(err.Error(), "closed network connection") {
+			t.Fatalf("RunAgent returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunAgent did not exit after context cancel")
+	}
+}
+
+func TestWaitForSocket_success(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "agent.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	ok := WaitForSocket(socketPath, 5, 10*time.Millisecond)
+	if !ok {
+		t.Fatal("WaitForSocket should return true for existing listener")
+	}
+}
+
+func TestWaitForSocket_timeout(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "nonexistent.sock")
+
+	ok := WaitForSocket(socketPath, 3, 10*time.Millisecond)
+	if ok {
+		t.Fatal("WaitForSocket should return false for non-existent socket")
+	}
+}

--- a/internal/sshushd/helpers_test.go
+++ b/internal/sshushd/helpers_test.go
@@ -1,0 +1,75 @@
+package sshushd
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFindBinary_notFound(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	bin, err := FindBinary()
+	if err == nil {
+		t.Fatalf("expected error, got binary %q", bin)
+	}
+	if !strings.Contains(err.Error(), "binary not found") {
+		t.Errorf("expected 'binary not found' in error, got %q", err.Error())
+	}
+}
+
+func TestStopDaemon_missingPidfile(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "nonexistent.pid")
+
+	err := StopDaemon(pidPath)
+	if err == nil {
+		t.Fatal("expected error for missing pidfile")
+	}
+	if !strings.Contains(err.Error(), "no pidfile") {
+		t.Errorf("expected 'no pidfile' in error, got %q", err.Error())
+	}
+}
+
+func TestStopDaemon_invalidPidfile(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "bad.pid")
+
+	if err := os.WriteFile(pidPath, []byte("not-a-number\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := StopDaemon(pidPath)
+	if err == nil {
+		t.Fatal("expected error for invalid pidfile")
+	}
+	if !strings.Contains(err.Error(), "invalid pidfile") {
+		t.Errorf("expected 'invalid pidfile' in error, got %q", err.Error())
+	}
+}
+
+func TestCheckAlreadyRunning_true(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "test.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	if !CheckAlreadyRunning(socketPath) {
+		t.Fatal("CheckAlreadyRunning should return true for existing listener")
+	}
+}
+
+func TestCheckAlreadyRunning_false(t *testing.T) {
+	dir := unixSocketTempDir(t)
+	socketPath := filepath.Join(dir, "nonexistent.sock")
+
+	if CheckAlreadyRunning(socketPath) {
+		t.Fatal("CheckAlreadyRunning should return false for non-existent socket")
+	}
+}


### PR DESCRIPTION
Add tests covering RunAgent, WaitForSocket, CheckAlreadyRunning, FindBinary, StopDaemon error paths, StartDaemon, StartServerDaemon, and ReloadDaemon error paths. Coverage improves from 10.1% to 37.8%.

Remaining uncovered:
RunDaemonOnly, RunServerOnly, detachProcess - call syscall.Setsid() which changes the process session. These are covered by e2e tests in test/e2e/.
Happy paths for StartDaemon/StartServerDaemon - require the sshushd binary to be compiled and spawnable.
Vault-open path in RunAgent — requires a valid vault file.