### PR TITLE
fix: replace syscall.Dup2 with platform-specific fd duplication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 )
 
@@ -45,6 +46,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 )

--- a/internal/sshushd/daemon.go
+++ b/internal/sshushd/daemon.go
@@ -188,8 +188,8 @@ func detachProcess() error {
 		return err
 	}
 	defer devNull.Close()
-	syscall.Dup2(int(devNull.Fd()), 0)
-	syscall.Dup2(int(devNull.Fd()), 1)
-	syscall.Dup2(int(devNull.Fd()), 2)
+	dupFd(int(devNull.Fd()), 0)
+	dupFd(int(devNull.Fd()), 1)
+	dupFd(int(devNull.Fd()), 2)
 	return nil
 }

--- a/internal/sshushd/fd_darwin.go
+++ b/internal/sshushd/fd_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package sshushd
+
+import "syscall"
+
+func dupFd(fd, target int) {
+	syscall.Dup2(fd, target)
+}

--- a/internal/sshushd/fd_linux.go
+++ b/internal/sshushd/fd_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package sshushd
+
+import "golang.org/x/sys/unix"
+
+func dupFd(fd, target int) {
+	unix.Dup2(fd, target)
+}


### PR DESCRIPTION
syscall.Dup2 was removed from Linux in Go 1.25+. Debian 13 ships Go 1.24 where it still exists, but the devcontainer (Go 1.26) fails.

- Add fd_darwin.go: uses syscall.Dup2 (works on macOS)
- Add fd_linux.go: uses golang.org/x/sys/unix.Dup2 (works on Linux)
- Extract dupFd() helper called from detachProcess()