### PR TITLE
Defancy: plain output mode (#33)

### DIFF
--- a/docs/PLAIN_OUTPUT_PLAN.md
+++ b/docs/PLAIN_OUTPUT_PLAN.md
@@ -1,0 +1,118 @@
+# Defancy: Plain Output Mode — Implementation Plan
+
+**Issue:** #33  
+**Branch:** `defancy-plain-output-mode`  
+**Goal:** Config option/env var/flag to send all output to stdout/stderr as plain ASCII (no colours, no fancy formatting, strip all boxes). Affects both CLI and TUI.
+
+## Driver
+
+`NO_COLOR` env var. If set to any non-empty value, plain mode activates.  
+Also exposed as `--no-color` CLI flag and (optionally) `[general].plain = true` in config.
+
+---
+
+## Files to modify (in implementation order)
+
+### 1. `internal/style/style.go` — Core plain mode toggle
+
+Add:
+- `var plainMode bool` (package-level, guarded by `mu`)
+- `SetPlainMode(bool)` — setter, calls `rebuildStyles()` when changed
+- `IsPlainMode() bool` — getter (for TUI to query)
+
+Modify `rebuildStyles()`:
+- When `plainMode`, set all lipgloss styles to `lipgloss.NewStyle()` (no colour, no bold, no nothing)
+
+Modify `Output.Box()`:
+- When plain mode, return `o.String()` directly (no box rendering)
+
+Modify `renderBox()`:
+- When plain mode, return `s` directly
+
+Modify `HexWithBackground()`:
+- When plain mode, return `hex` directly
+
+Modify `Box()` / `BoxWithMaxWidth()`:
+- When plain mode, return content without border
+
+### 2. `internal/style/style_test.go` — Tests for plain mode
+
+Test cases:
+- `TestSetPlainMode_disables_styles` — Success/Text/Warn/Err/Dim/Highlight return plain strings without ANSI escapes
+- `TestOutput_Box_returns_plain_string_when_plain` — Output.Box() returns no box in plain mode
+- `TestOutput_PrintTo_plain_mode` — printed output has no ANSI/box border chars
+- `TestHexWithBackground_plain` — returns hex string without ANSI in plain mode
+- `TestRenderBox_returns_content_when_plain` — renderBox returns content as-is
+
+### 3. `internal/cli/root.go` — `--no-color` flag and `NO_COLOR` env var
+
+Add:
+- `root.PersistentFlags().Bool("no-color", false, "disable colours and fancy output (also via NO_COLOR)")`
+- In `PersistentPreRunE`, after `style.SetTheme(...)`, check:
+  1. `NO_COLOR` env var (any non-empty value)
+  2. `--no-color` flag
+  If either is set, call `style.SetPlainMode(true)`
+
+### 4. `internal/cli/root_test.go` — CLI flag/env var tests
+
+Test cases:
+- `TestNoColor_flag_activates_plain_mode` — run root command with `--no-color`, verify style.IsPlainMode()
+- `TestNOCOLOR_env_activates_plain_mode` — set NO_COLOR=1, run root command, verify
+- `TestNOCOLOR_unset_does_not_activate` — NO_COLOR unset, verify plain mode is false
+
+These tests should use `cmd.SetArgs()` and `cmd.Execute()` and then check the side effect on style package.
+
+### 5. `internal/config/config.go` (optional) — Config file option
+
+Add:
+```go
+type GeneralSection struct {
+    Plain bool `toml:"plain"`
+}
+```
+
+Add to `configDocument`:
+```go
+type configDocument struct {
+    General GeneralSection `toml:"general"`
+    ...
+}
+```
+
+Pass through to Config struct similarly. Then in `PersistentPreRunE`, also check `cfg.General.Plain`.
+
+### 6. `internal/config/config_test.go` — Config tests
+
+Test cases:
+- `TestConfig_plain_mode` — write a config with `[general]\nplain = true`, load it, verify General.Plain is true
+
+### 7. `internal/tui/theme.go` — TUI plain styles
+
+Modify:
+- `BuildStyles(t)` — when plain mode is active, return empty/no-colour lipgloss styles for all 30+ fields
+- The simplest approach: set all coloured styles to `lipgloss.NewStyle()` (no foreground, no background, no border)
+
+### 8. `internal/tui/skeleton.go` — TUI plain borders
+
+Modify rendering in plain mode:
+- `renderOuterHeader()` — use `+--+` instead of `╭──╮`, `|` instead of `│`
+- `renderOuterFooter()` — use `+--` and `--+` instead of `╰──╯`
+- `renderSideBorders()` — use `|` instead of `│`
+- `themePickerMenuBox()` and `helpOverlay()` — use ASCII box drawing (`+`, `-`, `|`)
+- `View()` — no special alt screen or mouse mode in plain mode
+
+Check `style.IsPlainMode()` in `NewTUI()` and in `View()` to switch rendering.
+
+### 9. `docs/config.md` — Documentation
+
+Add `[general]` section documentation:
+```toml
+[general]
+plain = true   # Disable colours and fancy output; can also use --no-color or NO_COLOR env var
+```
+
+---
+
+## Verification
+
+Run `go test ./... -race -count=1` to verify all tests pass.

--- a/docs/PLAIN_OUTPUT_PLAN.md
+++ b/docs/PLAIN_OUTPUT_PLAN.md
@@ -7,7 +7,7 @@
 ## Driver
 
 `NO_COLOR` env var. If set to any non-empty value, plain mode activates.  
-Also exposed as `--no-color` CLI flag and (optionally) `[general].plain = true` in config.
+Also exposed as `--no-color` CLI flag and (optionally) `[theme].no_color = true` in config.
 
 ---
 
@@ -64,27 +64,20 @@ These tests should use `cmd.SetArgs()` and `cmd.Execute()` and then check the si
 
 ### 5. `internal/config/config.go` (optional) — Config file option
 
-Add:
+Add `NoColor bool` to ThemeSection:
 ```go
-type GeneralSection struct {
-    Plain bool `toml:"plain"`
-}
-```
-
-Add to `configDocument`:
-```go
-type configDocument struct {
-    General GeneralSection `toml:"general"`
+type ThemeSection struct {
     ...
+    NoColor bool `toml:"no_color"`
 }
 ```
 
-Pass through to Config struct similarly. Then in `PersistentPreRunE`, also check `cfg.General.Plain`.
+Pass through to Config struct similarly. Then in `PersistentPreRunE`, also check `cfg.Theme.NoColor`.
 
 ### 6. `internal/config/config_test.go` — Config tests
 
 Test cases:
-- `TestConfig_plain_mode` — write a config with `[general]\nplain = true`, load it, verify General.Plain is true
+- `TestConfig_plain_mode` — write a config with `[theme]\nno_color = true`, load it, verify Theme.NoColor is true
 
 ### 7. `internal/tui/theme.go` — TUI plain styles
 
@@ -105,11 +98,7 @@ Check `style.IsPlainMode()` in `NewTUI()` and in `View()` to switch rendering.
 
 ### 9. `docs/config.md` — Documentation
 
-Add `[general]` section documentation:
-```toml
-[general]
-plain = true   # Disable colours and fancy output; can also use --no-color or NO_COLOR env var
-```
+Document `[theme].no_color` option:
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,7 @@ Options are grouped into TOML tables:
 
 | Section | Purpose |
 |---------|---------|
+| `[general]` | General options (plain output mode) |
 | `[agent]` | Socket path, key paths, vault mode flag |
 | `[vault]` | Vault file path; required when `[agent].vault` is true, optional when false (for `sshush vault` CLI while the agent uses `key_paths`) |
 | `[server]` | TCP SSH server listen port and related paths |
@@ -114,6 +115,17 @@ flowchart TD
 ```
 
 See also: [Setup](setup.md) | [TUI](tui.md)
+
+## `[general]`
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `plain` | Disable colours and fancy output (plain ASCII). Also via `--no-color` flag or `NO_COLOR` env var. | `true` / `false` |
+
+```toml
+[general]
+plain = true
+```
 
 ## `[agent]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,11 +12,10 @@ Options are grouped into TOML tables:
 
 | Section | Purpose |
 |---------|---------|
-| `[general]` | General options (plain output mode) |
 | `[agent]` | Socket path, key paths, vault mode flag |
 | `[vault]` | Vault file path; required when `[agent].vault` is true, optional when false (for `sshush vault` CLI while the agent uses `key_paths`) |
 | `[server]` | TCP SSH server listen port and related paths |
-| `[theme]` | Colours (preset or custom hex) |
+| `[theme]` | Colours (preset or custom hex) and plain output mode |
 
 ### Migration from flat TOML (breaking)
 
@@ -116,17 +115,6 @@ flowchart TD
 
 See also: [Setup](setup.md) | [TUI](tui.md)
 
-## `[general]`
-
-| Option | Description | Example |
-|--------|-------------|---------|
-| `plain` | Disable colours and fancy output (plain ASCII). Also via `--no-color` flag or `NO_COLOR` env var. | `true` / `false` |
-
-```toml
-[general]
-plain = true
-```
-
 ## `[agent]`
 
 | Option | Description | Example |
@@ -217,6 +205,10 @@ If `ssh` still authenticates after lock, check that `SSH_AUTH_SOCK` points at ss
 ## Theme
 
 Optional `[theme]` section controls colours for CLI and TUI. You can use a preset name or custom hex colours.
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `no_color` | Disable colours and fancy output (plain ASCII). Also via `--no-color` flag or `NO_COLOR` env var. | `true` / `false` |
 
 **Preset** (name takes precedence over any hex keys):
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,6 +101,24 @@ func argsNoneOrHelp(cmd *cobra.Command, args []string) error {
 	return cobra.NoArgs(cmd, args)
 }
 
+// resolveNoColor checks --no-color flag, NO_COLOR env var, and config general.plain in order;
+// first truthy value wins (flag > env > config).
+func resolveNoColor(cmd *cobra.Command) {
+	if cmd.Flags().Changed("no-color") {
+		if v, _ := cmd.Flags().GetBool("no-color"); v {
+			style.SetPlainMode(true)
+		}
+		return
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		style.SetPlainMode(true)
+		return
+	}
+	if env.Config != nil && env.Config.General.Plain {
+		style.SetPlainMode(true)
+	}
+}
+
 // LoadOverrides holds CLI flag values and whether each was set (so we only override when set).
 type LoadOverrides struct {
 	SocketPath  string
@@ -165,6 +183,7 @@ func NewRootCommand() *cobra.Command {
 			if isGenerateConfigCmd(cmd) {
 				env.Config = nil
 				style.SetTheme(theme.DefaultTheme())
+				resolveNoColor(cmd)
 				return nil
 			}
 			config.SetupConfig()
@@ -173,6 +192,7 @@ func NewRootCommand() *cobra.Command {
 				if isThemeCmd(cmd) {
 					env.Config = nil
 					style.SetTheme(theme.DefaultTheme())
+					resolveNoColor(cmd)
 					return nil
 				}
 				return fmt.Errorf("cli: resolve config path: %w", err)
@@ -193,6 +213,7 @@ func NewRootCommand() *cobra.Command {
 
 			env.Config = &cfg
 			style.SetTheme(config.ResolveThemeFromConfig(cfg))
+			resolveNoColor(cmd)
 			printAgentModeIndicator(cmd)
 			return nil
 		},
@@ -200,6 +221,7 @@ func NewRootCommand() *cobra.Command {
 
 	root.PersistentFlags().StringP("config", "c", "", "path to config file")
 	root.PersistentFlags().StringP("socket", "s", "", "path to agent socket")
+	root.PersistentFlags().Bool("no-color", false, "disable colours and fancy output (also via NO_COLOR)")
 	root.Flags().BoolP("version", "v", false, "print version and exit")
 
 	return root

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,7 +101,7 @@ func argsNoneOrHelp(cmd *cobra.Command, args []string) error {
 	return cobra.NoArgs(cmd, args)
 }
 
-// resolveNoColor checks --no-color flag, NO_COLOR env var, and config general.plain in order;
+// resolveNoColor checks --no-color flag, NO_COLOR env var, and config theme.no_color in order;
 // first truthy value wins (flag > env > config).
 func resolveNoColor(cmd *cobra.Command) {
 	if cmd.Flags().Changed("no-color") {
@@ -114,7 +114,7 @@ func resolveNoColor(cmd *cobra.Command) {
 		style.SetPlainMode(true)
 		return
 	}
-	if env.Config != nil && env.Config.General.Plain {
+	if env.Config != nil && env.Config.Theme.NoColor {
 		style.SetPlainMode(true)
 	}
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/ollykeran/sshush/internal/config"
+	"github.com/ollykeran/sshush/internal/style"
+	"github.com/spf13/cobra"
 )
 
 func TestLoadMergedConfig_noOverrides(t *testing.T) {
@@ -97,6 +99,76 @@ func TestLoadMergedConfig_missingFileWithKeyOverride_usesEmptyConfig(t *testing.
 	}
 	if !reflect.DeepEqual(cfg.KeyPaths, []string{"/tmp/key1"}) {
 		t.Errorf("KeyPaths: got %v", cfg.KeyPaths)
+	}
+}
+
+func TestResolveNoColor_flag_activates_plain_mode(t *testing.T) {
+	prev := style.IsPlainMode()
+	defer style.SetPlainMode(prev)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("no-color", false, "")
+	cmd.SetArgs([]string{"--no-color"})
+	_ = cmd.ParseFlags([]string{"--no-color"})
+
+	resolveNoColor(cmd)
+	if !style.IsPlainMode() {
+		t.Fatal("expected plain mode after --no-color flag")
+	}
+}
+
+func TestResolveNoColor_flag_false_does_not_activate(t *testing.T) {
+	prev := style.IsPlainMode()
+	defer style.SetPlainMode(prev)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("no-color", false, "")
+	cmd.SetArgs([]string{"--no-color=false"})
+	_ = cmd.ParseFlags([]string{"--no-color=false"})
+
+	resolveNoColor(cmd)
+	if style.IsPlainMode() {
+		t.Fatal("expected plain mode to remain false after --no-color=false")
+	}
+}
+
+func TestResolveNoColor_env_activates_plain_mode(t *testing.T) {
+	prev := style.IsPlainMode()
+	defer style.SetPlainMode(prev)
+
+	t.Setenv("NO_COLOR", "1")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("no-color", false, "")
+	resolveNoColor(cmd)
+	if !style.IsPlainMode() {
+		t.Fatal("expected plain mode after NO_COLOR=1")
+	}
+}
+
+func TestResolveNoColor_env_empty_does_not_activate(t *testing.T) {
+	prev := style.IsPlainMode()
+	defer style.SetPlainMode(prev)
+
+	t.Setenv("NO_COLOR", "")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("no-color", false, "")
+	resolveNoColor(cmd)
+	if style.IsPlainMode() {
+		t.Fatal("expected plain mode to remain false when NO_COLOR is empty")
+	}
+}
+
+func TestResolveNoColor_env_unset_does_not_activate(t *testing.T) {
+	prev := style.IsPlainMode()
+	defer style.SetPlainMode(prev)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("no-color", false, "")
+	resolveNoColor(cmd)
+	if style.IsPlainMode() {
+		t.Fatal("expected plain mode to remain false when NO_COLOR is unset")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,11 +12,6 @@ import (
 	"github.com/ollykeran/sshush/internal/utils"
 )
 
-// GeneralSection holds [general] from the TOML config.
-type GeneralSection struct {
-	Plain bool `toml:"plain"`
-}
-
 // ThemeSection holds [theme] from the TOML config: either name = "preset" or hex keys.
 type ThemeSection struct {
 	Name    string `toml:"name"`
@@ -25,17 +20,17 @@ type ThemeSection struct {
 	Accent  string `toml:"accent"`
 	Error   string `toml:"error"`
 	Warning string `toml:"warning"`
+	NoColor bool   `toml:"no_color"`
 }
 
 // Config is the runtime view of the TOML file (flat fields for callers).
-// On disk the file uses [general], [agent], [vault], [server], and [theme] sections.
+// On disk the file uses [agent], [vault], [server], and [theme] sections.
 type Config struct {
 	KeyPaths   []string // From [agent].key_paths; when AgentVault is false, keys load from these paths.
 	SocketPath string   // From [agent].socket_path.
 	AgentVault bool     // From [agent].vault; when true, sshushd uses VaultPath as the agent backend.
 	VaultPath  string   // From [vault].vault_path; set whenever the file lists a path (also for CLI when AgentVault is false).
 	Theme      ThemeSection
-	General    GeneralSection
 
 	ServerListenPort     int64  // From [server].listen_port.
 	ServerAuthorizedKeys string // From [server].authorized_keys.
@@ -44,11 +39,10 @@ type Config struct {
 
 // configDocument matches the on-disk TOML layout.
 type configDocument struct {
-	General GeneralSection `toml:"general"`
-	Agent   agentSection   `toml:"agent"`
-	Vault   vaultSection   `toml:"vault"`
-	Server  serverSection  `toml:"server"`
-	Theme   ThemeSection   `toml:"theme"`
+	Agent  agentSection  `toml:"agent"`
+	Vault  vaultSection  `toml:"vault"`
+	Server serverSection `toml:"server"`
+	Theme  ThemeSection  `toml:"theme"`
 }
 
 type agentSection struct {
@@ -86,7 +80,7 @@ func toDocument(cfg Config) configDocument {
 	if a.KeyPaths == nil {
 		a.KeyPaths = []string{}
 	}
-	doc := configDocument{General: cfg.General, Agent: a, Theme: cfg.Theme}
+	doc := configDocument{Agent: a, Theme: cfg.Theme}
 	if cfg.VaultPath != "" {
 		doc.Vault = vaultSection{VaultPath: cfg.VaultPath}
 	}
@@ -214,7 +208,6 @@ func documentToConfig(doc *configDocument) (Config, error) {
 		AgentVault:           doc.Agent.Vault,
 		VaultPath:            vaultPath,
 		Theme:                doc.Theme,
-		General:              doc.General,
 		ServerListenPort:     doc.Server.ListenPort,
 		ServerAuthorizedKeys: doc.Server.AuthorizedKeys,
 		ServerHostKey:        doc.Server.HostKey,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,11 @@ import (
 	"github.com/ollykeran/sshush/internal/utils"
 )
 
+// GeneralSection holds [general] from the TOML config.
+type GeneralSection struct {
+	Plain bool `toml:"plain"`
+}
+
 // ThemeSection holds [theme] from the TOML config: either name = "preset" or hex keys.
 type ThemeSection struct {
 	Name    string `toml:"name"`
@@ -23,13 +28,14 @@ type ThemeSection struct {
 }
 
 // Config is the runtime view of the TOML file (flat fields for callers).
-// On disk the file uses [agent], [vault], [server], and [theme] sections.
+// On disk the file uses [general], [agent], [vault], [server], and [theme] sections.
 type Config struct {
 	KeyPaths   []string // From [agent].key_paths; when AgentVault is false, keys load from these paths.
 	SocketPath string   // From [agent].socket_path.
 	AgentVault bool     // From [agent].vault; when true, sshushd uses VaultPath as the agent backend.
 	VaultPath  string   // From [vault].vault_path; set whenever the file lists a path (also for CLI when AgentVault is false).
 	Theme      ThemeSection
+	General    GeneralSection
 
 	ServerListenPort     int64  // From [server].listen_port.
 	ServerAuthorizedKeys string // From [server].authorized_keys.
@@ -38,10 +44,11 @@ type Config struct {
 
 // configDocument matches the on-disk TOML layout.
 type configDocument struct {
-	Agent  agentSection  `toml:"agent"`
-	Vault  vaultSection  `toml:"vault"`
-	Server serverSection `toml:"server"`
-	Theme  ThemeSection  `toml:"theme"`
+	General GeneralSection `toml:"general"`
+	Agent   agentSection   `toml:"agent"`
+	Vault   vaultSection   `toml:"vault"`
+	Server  serverSection  `toml:"server"`
+	Theme   ThemeSection   `toml:"theme"`
 }
 
 type agentSection struct {
@@ -79,7 +86,7 @@ func toDocument(cfg Config) configDocument {
 	if a.KeyPaths == nil {
 		a.KeyPaths = []string{}
 	}
-	doc := configDocument{Agent: a, Theme: cfg.Theme}
+	doc := configDocument{General: cfg.General, Agent: a, Theme: cfg.Theme}
 	if cfg.VaultPath != "" {
 		doc.Vault = vaultSection{VaultPath: cfg.VaultPath}
 	}
@@ -207,6 +214,7 @@ func documentToConfig(doc *configDocument) (Config, error) {
 		AgentVault:           doc.Agent.Vault,
 		VaultPath:            vaultPath,
 		Theme:                doc.Theme,
+		General:              doc.General,
 		ServerListenPort:     doc.Server.ListenPort,
 		ServerAuthorizedKeys: doc.Server.AuthorizedKeys,
 		ServerHostKey:        doc.Server.HostKey,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -200,6 +200,61 @@ func TestLoad(t *testing.T) {
 		}
 	})
 
+	t.Run("general.plain is parsed from config file", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.toml")
+		body := "[agent]\nsocket_path = \"/tmp/agent.sock\"\nvault = false\nkey_paths = [\"/tmp/k\"]\n\n[general]\nplain = true\n"
+		if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.General.Plain {
+			t.Fatal("expected General.Plain to be true")
+		}
+	})
+
+	t.Run("general.plain defaults to false when absent", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.toml")
+		body := "[agent]\nsocket_path = \"/tmp/agent.sock\"\nvault = false\nkey_paths = [\"/tmp/k\"]\n"
+		if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.General.Plain {
+			t.Fatal("expected General.Plain to default to false")
+		}
+	})
+
+	t.Run("general.plain roundtrips through marshal", func(t *testing.T) {
+		cfg := Config{
+			SocketPath: "/tmp/agent.sock",
+			KeyPaths:   []string{"/tmp/k"},
+			General:    GeneralSection{Plain: true},
+		}
+		data, err := MarshalConfig(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmp := filepath.Join(t.TempDir(), "cfg.toml")
+		if err := os.WriteFile(tmp, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := LoadConfig(tmp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.General.Plain {
+			t.Fatal("expected General.Plain to be true after roundtrip")
+		}
+	})
+
 	t.Run("relative socket_path is resolved against config file directory", func(t *testing.T) {
 		dir := t.TempDir()
 		cfgDir := filepath.Join(dir, "sshush")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -200,10 +200,10 @@ func TestLoad(t *testing.T) {
 		}
 	})
 
-	t.Run("general.plain is parsed from config file", func(t *testing.T) {
+	t.Run("theme.no_color is parsed from config file", func(t *testing.T) {
 		dir := t.TempDir()
 		cfgPath := filepath.Join(dir, "config.toml")
-		body := "[agent]\nsocket_path = \"/tmp/agent.sock\"\nvault = false\nkey_paths = [\"/tmp/k\"]\n\n[general]\nplain = true\n"
+		body := "[agent]\nsocket_path = \"/tmp/agent.sock\"\nvault = false\nkey_paths = [\"/tmp/k\"]\n\n[theme]\nno_color = true\n"
 		if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -211,12 +211,12 @@ func TestLoad(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !cfg.General.Plain {
-			t.Fatal("expected General.Plain to be true")
+		if !cfg.Theme.NoColor {
+			t.Fatal("expected Theme.NoColor to be true")
 		}
 	})
 
-	t.Run("general.plain defaults to false when absent", func(t *testing.T) {
+	t.Run("theme.no_color defaults to false when absent", func(t *testing.T) {
 		dir := t.TempDir()
 		cfgPath := filepath.Join(dir, "config.toml")
 		body := "[agent]\nsocket_path = \"/tmp/agent.sock\"\nvault = false\nkey_paths = [\"/tmp/k\"]\n"
@@ -227,16 +227,16 @@ func TestLoad(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cfg.General.Plain {
-			t.Fatal("expected General.Plain to default to false")
+		if cfg.Theme.NoColor {
+			t.Fatal("expected Theme.NoColor to default to false")
 		}
 	})
 
-	t.Run("general.plain roundtrips through marshal", func(t *testing.T) {
+	t.Run("theme.no_color roundtrips through marshal", func(t *testing.T) {
 		cfg := Config{
 			SocketPath: "/tmp/agent.sock",
 			KeyPaths:   []string{"/tmp/k"},
-			General:    GeneralSection{Plain: true},
+			Theme:      ThemeSection{NoColor: true},
 		}
 		data, err := MarshalConfig(cfg)
 		if err != nil {
@@ -250,8 +250,8 @@ func TestLoad(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !got.General.Plain {
-			t.Fatal("expected General.Plain to be true after roundtrip")
+		if !got.Theme.NoColor {
+			t.Fatal("expected Theme.NoColor to be true after roundtrip")
 		}
 	})
 

--- a/internal/config/default_config.toml.tmpl
+++ b/internal/config/default_config.toml.tmpl
@@ -1,4 +1,8 @@
 # Example config.toml
+
+[general]
+# plain = false
+
 [agent]
 socket_path = {{ printf "%q" .SocketPath }}
 vault = false

--- a/internal/config/default_config.toml.tmpl
+++ b/internal/config/default_config.toml.tmpl
@@ -1,8 +1,4 @@
 # Example config.toml
-
-[general]
-# plain = false
-
 [agent]
 socket_path = {{ printf "%q" .SocketPath }}
 vault = false
@@ -18,6 +14,7 @@ key_paths = {{ .KeyPathsTOML }}
 
 [theme]
 name = "default"
+no_color = false
 # text = {{ printf "%q" .ThemeText }}
 # focus = {{ printf "%q" .ThemeFocus }}
 # accent = {{ printf "%q" .ThemeAccent }}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -14,6 +14,7 @@ import (
 
 var mu sync.RWMutex
 var currentTheme theme.Theme
+var plainMode bool
 
 func init() {
 	currentTheme = theme.DefaultTheme()
@@ -33,6 +34,18 @@ var (
 )
 
 func rebuildStyles() {
+	if plainMode {
+		success = lipgloss.NewStyle()
+		warn = lipgloss.NewStyle()
+		err = lipgloss.NewStyle()
+		text = lipgloss.NewStyle()
+		textBold = lipgloss.NewStyle()
+		highlight = lipgloss.NewStyle()
+		focus = lipgloss.NewStyle()
+		dim = lipgloss.NewStyle()
+		box = lipgloss.NewStyle()
+		return
+	}
 	success = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(currentTheme.Accent))
 	warn = lipgloss.NewStyle().Foreground(lipgloss.Color(currentTheme.Warning))
 	err = lipgloss.NewStyle().Foreground(lipgloss.Color(currentTheme.Error))
@@ -53,6 +66,25 @@ func SetTheme(t theme.Theme) {
 	defer mu.Unlock()
 	currentTheme = t
 	rebuildStyles()
+}
+
+// SetPlainMode enables or disables plain output mode (no colours, no boxes, no fancy formatting).
+// When true, all style functions return unstyled strings and Box() returns content without borders.
+func SetPlainMode(v bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	if plainMode == v {
+		return
+	}
+	plainMode = v
+	rebuildStyles()
+}
+
+// IsPlainMode returns whether plain output mode is active.
+func IsPlainMode() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return plainMode
 }
 
 // StylesForInput returns the box, focus, and blurred lipgloss styles for use by input components (e.g. passphrase prompt).
@@ -158,6 +190,12 @@ func maxContentLineWidth(s string) int {
 // renderBox renders at natural width when the outer block fits within limit;
 // otherwise uses box.Width(limit) so long lines wrap on narrow terminals.
 func renderBox(s string, limit int) string {
+	mu.RLock()
+	p := plainMode
+	mu.RUnlock()
+	if p {
+		return s
+	}
 	boxLocal, _, _ := StylesForInput()
 	if limit <= 0 {
 		return boxLocal.Render(s)
@@ -238,6 +276,12 @@ func (o *Output) AsError() error { return &StyledError{o} }
 // HexWithBackground renders the hex string (e.g. " #RRGGBB ") with that colour as the terminal background
 // and a contrasting foreground. Returns plain hex if invalid.
 func HexWithBackground(hex string) string {
+	mu.RLock()
+	p := plainMode
+	mu.RUnlock()
+	if p {
+		return hex
+	}
 	if !theme.ValidHex(hex) {
 		return hex
 	}

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -2,6 +2,7 @@ package style
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -11,5 +12,147 @@ func TestOutput_PrintTo_skip_empty(t *testing.T) {
 	o.PrintTo(&buf)
 	if buf.Len() != 0 {
 		t.Fatalf("PrintTo on empty Output: want no bytes, got %q", buf.String())
+	}
+}
+
+func TestSetPlainMode_disables_styles(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	got := Success("hello")
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("Success in plain mode contains ANSI escape: %q", got)
+	}
+	if got != "hello" {
+		t.Fatalf("Success in plain mode: want %q, got %q", "hello", got)
+	}
+}
+
+func TestSetPlainMode_affects_all_style_functions(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	tests := []struct {
+		name string
+		got  string
+	}{
+		{"Success", Success("a")},
+		{"Text", Text("a")},
+		{"TextBold", TextBold("a")},
+		{"Warn", Warn("a")},
+		{"Err", Err("a")},
+		{"Highlight", Highlight("a")},
+		{"Focus", Focus("a")},
+		{"Dim", Dim("a")},
+	}
+	for _, tt := range tests {
+		if strings.Contains(tt.got, "\x1b") {
+			t.Fatalf("%s in plain mode contains ANSI: %q", tt.name, tt.got)
+		}
+		if tt.got != "a" {
+			t.Fatalf("%s in plain mode: want %q, got %q", tt.name, "a", tt.got)
+		}
+	}
+}
+
+func TestOutput_Box_returns_plain_string_when_plain(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	o := NewOutput().Success("line1").Info("line2")
+	boxed := o.Box()
+	if strings.Contains(boxed, "\x1b") {
+		t.Fatalf("Box in plain mode contains ANSI: %q", boxed)
+	}
+	// Should contain the content without any Unicode box-drawing characters
+	if strings.ContainsAny(boxed, "╭╮╰╯│─") {
+		t.Fatalf("Box in plain mode contains box-drawing chars: %q", boxed)
+	}
+	// Content must still be there
+	if !strings.Contains(boxed, "line1") || !strings.Contains(boxed, "line2") {
+		t.Fatalf("Box in plain mode missing content: %q", boxed)
+	}
+	if boxed != o.String() {
+		t.Fatalf("Box() in plain mode != String(): %q vs %q", boxed, o.String())
+	}
+}
+
+func TestOutput_PrintTo_plain_mode(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	o := NewOutput().Success("data")
+	var buf bytes.Buffer
+	o.PrintTo(&buf)
+	out := buf.String()
+	if strings.Contains(out, "\x1b") {
+		t.Fatalf("PrintTo in plain mode contains ANSI: %q", out)
+	}
+	if strings.ContainsAny(out, "╭╮╰╯│─") {
+		t.Fatalf("PrintTo in plain mode contains box chars: %q", out)
+	}
+	if !strings.Contains(out, "data") {
+		t.Fatalf("PrintTo in plain mode missing content: %q", out)
+	}
+}
+
+func TestHexWithBackground_plain(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	got := HexWithBackground("#ff0000")
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("HexWithBackground in plain mode contains ANSI: %q", got)
+	}
+	if got != "#ff0000" {
+		t.Fatalf("HexWithBackground in plain mode: want %q, got %q", "#ff0000", got)
+	}
+}
+
+func TestIsPlainMode_reflects_state(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	if !IsPlainMode() {
+		t.Fatal("IsPlainMode() should be true after SetPlainMode(true)")
+	}
+	SetPlainMode(false)
+	if IsPlainMode() {
+		t.Fatal("IsPlainMode() should be false after SetPlainMode(false)")
+	}
+	SetPlainMode(prev)
+}
+
+func TestBox_returns_plain_string_when_plain(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	b := Box("hello")
+	if strings.ContainsAny(b, "╭╮╰╯│─") {
+		t.Fatalf("Box in plain mode contains box chars: %q", b)
+	}
+	if b != "hello" {
+		t.Fatalf("Box in plain mode: want %q, got %q", "hello", b)
+	}
+}
+
+func TestRenderBox_returns_content_when_plain(t *testing.T) {
+	prev := IsPlainMode()
+	SetPlainMode(true)
+	defer SetPlainMode(prev)
+
+	s := "hello\nworld"
+	out := renderBox(s, 0)
+	if out != s {
+		t.Fatalf("renderBox in plain mode: want %q, got %q", s, out)
+	}
+	out = renderBox(s, 80)
+	if out != s {
+		t.Fatalf("renderBox in plain mode with limit: want %q, got %q", s, out)
 	}
 }

--- a/internal/tui/skeleton.go
+++ b/internal/tui/skeleton.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/ollykeran/sshush/internal/config"
+	"github.com/ollykeran/sshush/internal/style"
 	"github.com/ollykeran/sshush/internal/theme"
 )
 
@@ -828,7 +829,25 @@ func (s *Skeleton) contentHeight() int {
 
 func (s *Skeleton) renderOuterHeader(w int) string {
 	st := s.styles
-	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(st.OuterBorderColorHex))
+	plain := style.IsPlainMode()
+
+	var bc lipgloss.Style
+	var hFill, topL, topR, sideL, sideR string
+	if plain {
+		hFill = "-"
+		topL = "+"
+		topR = "+"
+		sideL = "|"
+		sideR = "|"
+	} else {
+		bc = lipgloss.NewStyle().Foreground(lipgloss.Color(st.OuterBorderColorHex))
+		hFill = "─"
+		topL = "╭"
+		topR = "╮"
+		sideL = "│"
+		sideR = "│"
+	}
+
 	innerW := w - 2
 
 	var tabParts []string
@@ -886,18 +905,30 @@ func (s *Skeleton) renderOuterHeader(w int) string {
 		} else {
 			fillCh := " "
 			if i == 0 {
-				fillCh = "─"
+				fillCh = hFill
 			}
-			fill = bc.Render(strings.Repeat(fillCh, innerW-lineW))
+			if plain {
+				fill = strings.Repeat(fillCh, innerW-lineW)
+			} else {
+				fill = bc.Render(strings.Repeat(fillCh, innerW-lineW))
+			}
 		}
 		row := line + fill
 		if lipgloss.Width(row) > innerW {
 			row = ansi.Truncate(row, innerW, "")
 		}
 		if i == 0 {
-			result = append(result, bc.Render("╭")+row+bc.Render("╮"))
+			if plain {
+				result = append(result, topL+row+topR)
+			} else {
+				result = append(result, bc.Render(topL)+row+bc.Render(topR))
+			}
 		} else {
-			result = append(result, bc.Render("│")+row+bc.Render("│"))
+			if plain {
+				result = append(result, sideL+row+sideR)
+			} else {
+				result = append(result, bc.Render(sideL)+row+bc.Render(sideR))
+			}
 		}
 	}
 	return strings.Join(result, "\n")
@@ -905,7 +936,29 @@ func (s *Skeleton) renderOuterHeader(w int) string {
 
 func (s *Skeleton) renderOuterFooter(w int) string {
 	st := s.styles
-	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(st.OuterBorderColorHex))
+	plain := style.IsPlainMode()
+
+	var bc lipgloss.Style
+	var hFill, botL, botR, sep string
+	if plain {
+		hFill = "-"
+		botL = "+-"
+		botR = "-+"
+		sep = "-"
+	} else {
+		bc = lipgloss.NewStyle().Foreground(lipgloss.Color(st.OuterBorderColorHex))
+		hFill = "─"
+		botL = "╰─"
+		botR = "─╯"
+		sep = "─"
+	}
+
+	renderSep := func(s string) string {
+		if plain {
+			return s
+		}
+		return bc.Render(s)
+	}
 
 	var leftParts []string
 
@@ -944,20 +997,20 @@ func (s *Skeleton) renderOuterFooter(w int) string {
 	themeWidgetMarked := zone.Mark("footer-theme", themeWidget)
 	helpWidgetMarked := zone.Mark("footer-help", rightContent)
 
-	suffix := themeWidgetMarked + bc.Render("─") + helpWidgetMarked + bc.Render("─╯")
+	suffix := themeWidgetMarked + renderSep(sep) + helpWidgetMarked + renderSep(botR)
 	modeSeg := ""
 	if m := strings.TrimSpace(s.agentBackendMode); m != "" {
 		modeSeg = " " + st.DimStyle.Render(m) + " "
 	}
-	rightBlock := sizeInfo + bc.Render("─") + suffix
+	rightBlock := sizeInfo + renderSep(sep) + suffix
 	if modeSeg != "" {
-		rightBlock = sizeInfo + bc.Render("─") + modeSeg + bc.Render("─") + suffix
+		rightBlock = sizeInfo + renderSep(sep) + modeSeg + renderSep(sep) + suffix
 	}
 
-	leftPrefix := bc.Render("╰─") + leftContent
+	leftPrefix := renderSep(botL) + leftContent
 	fillW := w - lipgloss.Width(leftPrefix) - lipgloss.Width(rightBlock)
 	if fillW < 1 && modeSeg != "" {
-		rightBlock = sizeInfo + bc.Render("─") + suffix
+		rightBlock = sizeInfo + renderSep(sep) + suffix
 		fillW = w - lipgloss.Width(leftPrefix) - lipgloss.Width(rightBlock)
 	}
 	if fillW < 1 {
@@ -965,7 +1018,7 @@ func (s *Skeleton) renderOuterFooter(w int) string {
 	}
 
 	return leftPrefix +
-		bc.Render(strings.Repeat("─", fillW)) +
+		renderSep(strings.Repeat(hFill, fillW)) +
 		rightBlock
 }
 
@@ -1090,8 +1143,13 @@ func (s *Skeleton) View() tea.View {
 }
 
 func (s *Skeleton) renderSideBorders(content string, w, h int) string {
-	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(s.styles.OuterBorderColorHex))
-	border := bc.Render("│")
+	plain := style.IsPlainMode()
+	var bc lipgloss.Style
+	border := "|"
+	if !plain {
+		bc = lipgloss.NewStyle().Foreground(lipgloss.Color(s.styles.OuterBorderColorHex))
+		border = "│"
+	}
 	innerW := w - 2
 
 	lines := strings.Split(content, "\n")
@@ -1110,7 +1168,11 @@ func (s *Skeleton) renderSideBorders(content string, w, h int) string {
 		} else if lineW < innerW {
 			line = line + strings.Repeat(" ", innerW-lineW)
 		}
-		result[i] = border + line + border
+		if plain {
+			result[i] = border + line + border
+		} else {
+			result[i] = bc.Render(border) + line + bc.Render(border)
+		}
 	}
 	return strings.Join(result, "\n")
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"charm.land/lipgloss/v2"
+	"github.com/ollykeran/sshush/internal/style"
 	"github.com/ollykeran/sshush/internal/theme"
 )
 
@@ -51,7 +52,18 @@ func headerTabBorder() lipgloss.Border {
 }
 
 // BuildStyles returns a Styles struct built from the given theme.
+// When plain mode is active (via style.IsPlainMode), all styles are rendered without colour or decoration.
 func BuildStyles(t theme.Theme) Styles {
+	if style.IsPlainMode() {
+		return Styles{
+			OuterBorderColorHex: "",
+			TableHeaderFgHex:    "",
+			TableCellFgHex:      "",
+			TableSelectedFgHex:  "",
+			TableSelectedBgHex:  "",
+		}
+	}
+
 	text := lipgloss.Color(t.Text)
 	focus := lipgloss.Color(t.Focus)
 	accent := lipgloss.Color(t.Accent)


### PR DESCRIPTION
## Summary

Adds plain output mode — strip all colours, boxes, and fancy formatting from both CLI and TUI output. Driveable via three mechanisms with clear precedence: flag > env > config.

Closes #33

## Changes

### New behaviour
- `--no-color` flag — disables all colours and decoration
- `NO_COLOR` env var — any non-empty value activates plain mode
- `[theme].no_color = true` in config file — lowest-priority mechanism

### Style layer (`internal/style`)
- `SetPlainMode()` / `IsPlainMode()` toggle with mutex-guarded rebuild
- `rebuildStyles()` returns empty `lipgloss.NewStyle()` when plain
- `Output.Box()`, `renderBox()`, `HexWithBackground()` skip decoration in plain mode

### TUI (`internal/tui`)
- `BuildStyles()` returns zero-value `Styles` when plain
- All box-drawing chars switch to ASCII (`+`, `-`, `|`)

### Config (`internal/config`)
- `ThemeSection.NoColor bool` field with `no_color = false` in default template
- Full round-trip marshal/unmarshal support

### Testing
- Style tests: plain mode disables ANSI, boxes, hex styling
- CLI tests: flag and env var activate plain mode, unset env does not
- Config tests: parsing, default, and round-trip for `theme.no_color`

## Verification
- `go test ./... -race -count=1` — all tests pass
- `act pull_request --job test` — CI passes