### PR TITLE
feat(tui): add vault lock indicator and lock/unlock controls

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"os"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/table"
 	"charm.land/bubbles/v2/textinput"
@@ -48,11 +49,34 @@ type agentUnlockResultMsg struct {
 	err error
 }
 
+// vaultStatusMsg reports the live backend mode of the running agent and, for vault
+// agents, whether the vault is locked (master key absent).
+type vaultStatusMsg struct {
+	mode      string // "vault" or "keys"
+	reachable bool   // agent socket reachable and state readable
+	locked    bool   // vault mode only: master key absent
+}
+
+// vaultPollMsg requests a periodic re-check of the vault lock state. gen identifies
+// the poll chain; stale chains are dropped after daemon stop/start.
+type vaultPollMsg struct {
+	gen int
+}
+
 const (
 	agentFocusButtons = iota
 	agentFocusTable
 	agentFocusFound
 	agentFocusPassphrase
+)
+
+// Indices into AgentScreen.buttons.Labels.
+const (
+	btnStart = iota
+	btnStop
+	btnReload
+	btnLock
+	btnUnlock
 )
 
 // AgentScreen is the agent tab: keys table, Start/Stop/Reload buttons, add/remove keys, lock/unlock.
@@ -79,6 +103,11 @@ type AgentScreen struct {
 	showPass   bool
 	passAction string // "lock" or "unlock"
 
+	vaultMode    string // live backend mode from the running agent ("vault"/"keys")
+	vaultLocked  bool   // true when the running vault agent reports locked
+	vaultKnown   bool   // true when the vault lock state has been read from a running agent
+	vaultPollGen int    // generation of the active vault poll chain
+
 	focus int
 }
 
@@ -91,7 +120,7 @@ func NewAgentScreen(sk *Skeleton, configPath, socketPath string) *AgentScreen {
 	pi.EchoMode = textinput.EchoPassword
 	pi.EchoCharacter = '*'
 
-	btns := NewButtonRow("[s]tart", "[x]stop", "[r]eload")
+	btns := NewButtonRow("[s]tart", "[x]stop", "[r]eload", "[L]ock", "[u]nlock")
 	btns.Focused = true
 	btns.ZonePrefix = prefix + "ctrl-"
 
@@ -121,6 +150,7 @@ func (s *AgentScreen) Init() tea.Cmd {
 	return tea.Batch(
 		fetchAgentKeysCmd(s.socketPath, false),
 		checkDaemonCmd(s.socketPath),
+		checkVaultStateCmd(s.socketPath),
 		discoverKeysCmd(),
 	)
 }
@@ -128,7 +158,7 @@ func (s *AgentScreen) Init() tea.Cmd {
 func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if s.fileSelector.Visible() {
 		switch msg.(type) {
-		case tea.WindowSizeMsg, FileSelectedMsg, FilePickerCancelledMsg, agentKeysMsg, agentStatusMsg, agentDaemonStateMsg, agentLockResultMsg, agentUnlockResultMsg, foundKeysMsg, ButtonFlashDoneMsg:
+		case tea.WindowSizeMsg, FileSelectedMsg, FilePickerCancelledMsg, agentKeysMsg, agentStatusMsg, agentDaemonStateMsg, agentLockResultMsg, agentUnlockResultMsg, vaultStatusMsg, vaultPollMsg, foundKeysMsg, ButtonFlashDoneMsg:
 			// Handle these below
 		default:
 			return s, s.fileSelector.Update(msg)
@@ -180,6 +210,17 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			s.sk.UpdateWidgetValue(daemonStatusWidgetID(), state)
 		}
+		if msg.running {
+			// Start a fresh vault poll chain; bumping the generation drops any stale chain.
+			s.vaultPollGen++
+			return s, pollVaultStateCmd(s.socketPath, s.vaultPollGen)
+		}
+		s.vaultKnown = false
+		s.vaultLocked = false
+		s.vaultPollGen++
+		if s.sk != nil {
+			s.sk.UpdateVaultState("", false, false)
+		}
 		return s, nil
 
 	case ButtonFlashDoneMsg:
@@ -203,7 +244,10 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		s.keyTable.SetRows(rows)
 		s.statusErr = false
-		if msg.refresh {
+		if s.vaultKnown && s.vaultLocked {
+			s.status = "vault locked - press u to unlock"
+			s.statusErr = true
+		} else if msg.refresh {
 			s.status = fmt.Sprintf("refreshed %d key(s)", len(rows))
 		} else if len(rows) == 0 {
 			s.status = "no keys loaded"
@@ -231,9 +275,10 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return s, tea.Batch(
 				fetchAgentKeysCmd(s.socketPath, false),
 				checkDaemonCmd(s.socketPath),
+				checkVaultStateCmd(s.socketPath),
 			)
 		}
-		return s, checkDaemonCmd(s.socketPath)
+		return s, tea.Batch(checkDaemonCmd(s.socketPath), checkVaultStateCmd(s.socketPath))
 
 	case foundKeysMsg:
 		s.foundKeys = msg.paths
@@ -248,9 +293,12 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			s.status = "agent locked"
 			s.statusErr = false
+			// Reset the cached lock state so the follow-up check refreshes it.
+			s.vaultKnown = false
+			s.vaultLocked = false
 		}
 		s.focus = agentFocusTable
-		return s, fetchAgentKeysCmd(s.socketPath, true)
+		return s, tea.Batch(fetchAgentKeysCmd(s.socketPath, true), checkVaultStateCmd(s.socketPath))
 
 	case agentUnlockResultMsg:
 		s.showPass = false
@@ -261,9 +309,39 @@ func (s *AgentScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			s.status = "agent unlocked"
 			s.statusErr = false
+			// Reset the cached lock state so the follow-up check refreshes it.
+			s.vaultKnown = false
+			s.vaultLocked = false
 		}
 		s.focus = agentFocusTable
-		return s, fetchAgentKeysCmd(s.socketPath, true)
+		return s, tea.Batch(fetchAgentKeysCmd(s.socketPath, true), checkVaultStateCmd(s.socketPath))
+
+	case vaultStatusMsg:
+		s.vaultMode = msg.mode
+		if msg.reachable {
+			s.vaultKnown = true
+			s.vaultLocked = msg.locked
+			if s.vaultLocked {
+				s.status = "vault locked - press u to unlock"
+				s.statusErr = true
+			}
+		} else {
+			s.vaultKnown = false
+			s.vaultLocked = false
+		}
+		if s.sk != nil {
+			s.sk.UpdateVaultState(s.vaultMode, s.vaultLocked, s.vaultKnown)
+		}
+		return s, nil
+
+	case vaultPollMsg:
+		if msg.gen != s.vaultPollGen || !s.daemonRunning {
+			return s, nil
+		}
+		return s, tea.Batch(
+			checkVaultStateCmd(s.socketPath),
+			pollVaultStateCmd(s.socketPath, msg.gen),
+		)
 
 	case tea.MouseReleaseMsg:
 		if msg.Button != tea.MouseLeft || s.fileSelector.Visible() || s.showPass {
@@ -347,20 +425,10 @@ func (s *AgentScreen) handleKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return s, nil
 
 	case "L":
-		s.showPass = true
-		s.passAction = "lock"
-		s.passInput.SetValue("")
-		s.passInput.Placeholder = "lock passphrase"
-		s.focus = agentFocusPassphrase
-		return s, s.passInput.Focus()
+		return s, s.startLock()
 
-	case "U":
-		s.showPass = true
-		s.passAction = "unlock"
-		s.passInput.SetValue("")
-		s.passInput.Placeholder = "unlock passphrase"
-		s.focus = agentFocusPassphrase
-		return s, s.passInput.Focus()
+	case "u":
+		return s, s.startPassphrase("unlock")
 	}
 
 	if s.focus == agentFocusTable {
@@ -408,22 +476,55 @@ func (s *AgentScreen) handleMouse(x, y int) (tea.Model, tea.Cmd) {
 
 func (s *AgentScreen) pressButton(btn int) (tea.Model, tea.Cmd) {
 	s.buttons.Active = btn
+	switch btn {
+	case btnLock:
+		return s, s.startLock()
+	case btnUnlock:
+		return s, s.startPassphrase("unlock")
+	}
 	s.buttons.Press()
 	s.statusErr = false
 
 	var action tea.Cmd
 	switch btn {
-	case 0: // Start
+	case btnStart: // Start
 		s.status = "starting..."
 		action = startDaemonCmd(s.configPath, s.socketPath)
-	case 1: // Stop
+	case btnStop: // Stop
 		s.status = "stopping..."
 		action = stopDaemonCmd()
-	case 2: // Reload
+	case btnReload: // Reload
 		s.status = "reloading..."
 		action = reloadDaemonCmd(s.configPath, s.socketPath)
 	}
 	return s, tea.Batch(action, ButtonFlashCmd())
+}
+
+// startPassphrase opens the lock/unlock passphrase prompt for the given action ("lock"/"unlock").
+func (s *AgentScreen) startPassphrase(action string) tea.Cmd {
+	s.showPass = true
+	s.passAction = action
+	s.passInput.SetValue("")
+	if action == "lock" {
+		s.passInput.Placeholder = "lock passphrase"
+	} else {
+		s.passInput.Placeholder = "unlock passphrase"
+	}
+	s.focus = agentFocusPassphrase
+	return s.passInput.Focus()
+}
+
+// startLock begins locking the agent. A live vault agent locks without a passphrase:
+// the daemon wipes the in-memory master key, so the global unlock key already held is
+// simply discarded. Keys-mode agents need a passphrase (it becomes the unlock key), so
+// the passphrase prompt is shown instead.
+func (s *AgentScreen) startLock() tea.Cmd {
+	if s.vaultMode == "vault" {
+		s.statusErr = false
+		s.status = "locking..."
+		return lockVaultCmd(s.socketPath)
+	}
+	return s.startPassphrase("lock")
 }
 
 func (s *AgentScreen) removeSelectedKey() (tea.Model, tea.Cmd) {
@@ -493,6 +594,9 @@ func (s *AgentScreen) View() tea.View {
 
 	st := s.sk.Styles()
 	keyBox := s.keyTable.FocusedBoxView(st, active && s.focus == agentFocusTable)
+	if s.vaultKnown && s.vaultLocked {
+		keyBox = s.keyTable.WarnBoxView(st)
+	}
 
 	var sections []string
 	sections = append(sections, lipgloss.Place(w, 0, lipgloss.Center, lipgloss.Top, keyBox))
@@ -629,6 +733,8 @@ func (s *AgentScreen) HelpEntries() []string {
 		st.HelpRow("Agent controls", ""),
 		st.HelpRow("a", "Add key"),
 		st.HelpRow("d / bksp", "Remove key"),
+		st.HelpRow("L", "Lock vault"),
+		st.HelpRow("u", "Unlock vault"),
 		"",
 	}
 }
@@ -718,10 +824,50 @@ func lockAgentCmd(socketPath, passphrase string) tea.Cmd {
 	}
 }
 
+// lockVaultCmd locks the vault agent immediately. Locking needs no passphrase: the
+// daemon wipes the in-memory master key.
+func lockVaultCmd(socketPath string) tea.Cmd {
+	return func() tea.Msg {
+		return agentLockResultMsg{err: agent.LockSocket(socketPath, nil)}
+	}
+}
+
 func unlockAgentCmd(socketPath, passphrase string) tea.Cmd {
 	return func() tea.Msg {
 		return agentUnlockResultMsg{err: agent.UnlockSocket(socketPath, []byte(passphrase))}
 	}
+}
+
+// checkVaultState queries the running agent for its backend mode and, for vault agents,
+// whether the vault is locked.
+func checkVaultState(socketPath string) vaultStatusMsg {
+	mode, live := agent.LiveBackendMode(socketPath)
+	if !live {
+		return vaultStatusMsg{}
+	}
+	if mode != "vault" {
+		return vaultStatusMsg{mode: mode, reachable: true}
+	}
+	resp, err := agent.CallExtension(socketPath, vault.ExtensionVaultLocked, nil)
+	if err != nil || len(resp) != 1 {
+		return vaultStatusMsg{mode: mode}
+	}
+	return vaultStatusMsg{mode: mode, reachable: true, locked: resp[0] == 1}
+}
+
+func checkVaultStateCmd(socketPath string) tea.Cmd {
+	return func() tea.Msg {
+		return checkVaultState(socketPath)
+	}
+}
+
+// pollVaultStateCmd schedules the next periodic vault state check. Only the poll chain
+// matching the current generation is kept; daemon stop/start bumps the generation to
+// drop stale chains.
+func pollVaultStateCmd(socketPath string, gen int) tea.Cmd {
+	return tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+		return vaultPollMsg{gen: gen}
+	})
 }
 
 func discoverKeysCmd() tea.Cmd {

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -161,6 +161,12 @@ func (kt KeyTable) FocusedBoxView(st Styles, focused bool) string {
 	return border.Render(kt.Table.View())
 }
 
+// WarnBoxView renders the key table with the warn-coloured border, used when the
+// vault is locked.
+func (kt KeyTable) WarnBoxView(st Styles) string {
+	return st.WarnBorderStyle.Render(kt.Table.View())
+}
+
 func (kt KeyTable) BoxView(st Styles) string {
 	return st.UnfocusedBorderStyle.Render(kt.Table.View())
 }
@@ -179,7 +185,7 @@ func keyBoxInnerWidth(termWidth int) int {
 const (
 	keyTableMinTotalWidth = 36
 	keyTableTypeMinWidth  = 19
-	keyTableFPMinWidth     = 30
+	keyTableFPMinWidth    = 30
 	keyTableCommentMinW   = 20
 )
 

--- a/internal/tui/skeleton.go
+++ b/internal/tui/skeleton.go
@@ -54,6 +54,9 @@ type Skeleton struct {
 	themeMessage            string      // footer message: session only, saved, save failed
 	themeMessageGeneration  int         // incremented each time message is set, so timeout only clears if still current
 	agentBackendMode        string      // "vault" or "keys"; shown in footer (from config at TUI start)
+	vaultMode               string      // live backend mode read from the running agent ("vault"/"keys")
+	vaultLocked             bool        // true when the running vault agent reports locked
+	vaultKnown              bool        // true when the vault lock state has been read from a running agent
 }
 
 // Styles returns the current styles (derived from theme). Use for all TUI rendering.
@@ -217,6 +220,14 @@ func (s *Skeleton) UpdateWidgetValue(id, value string) {
 		}
 	}
 	s.AddWidget(id, value)
+}
+
+// UpdateVaultState records the live vault lock state read from the running agent.
+// mode is "vault"/"keys"/""; known is false when no live state is available (daemon stopped).
+func (s *Skeleton) UpdateVaultState(mode string, locked, known bool) {
+	s.vaultMode = mode
+	s.vaultLocked = locked
+	s.vaultKnown = known
 }
 
 func (s *Skeleton) GetTerminalWidth() int {
@@ -398,24 +409,45 @@ func (s *Skeleton) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// Global daemon hotkeys s/x/r (when not in text input; theme picker keeps "s" for save)
-		if (key == "s" || key == "x" || key == "r") && !s.showThemePicker {
+		// Global daemon hotkeys s/x/r/L/u (when not in text input; theme picker keeps "s" for save).
+		// L/u switch to the agent tab and take screen focus when the passphrase prompt opens
+		// (a vault agent locks immediately without one).
+		if (key == "s" || key == "x" || key == "r" || key == "L" || key == "u") && !s.showThemePicker {
 			textInputActive := false
 			if tip, ok := s.pages[s.activeTab].model.(interface{ HasActiveTextInput() bool }); ok {
 				textInputActive = tip.HasActiveTextInput()
 			}
 			if !textInputActive {
 				if agent := s.agentScreen(); agent != nil {
-					var cmd tea.Cmd
 					switch key {
 					case "s":
-						_, cmd = agent.pressButton(0)
+						_, cmd := agent.pressButton(btnStart)
+						return s, cmd
 					case "x":
-						_, cmd = agent.pressButton(1)
+						_, cmd := agent.pressButton(btnStop)
+						return s, cmd
 					case "r":
-						_, cmd = agent.pressButton(2)
+						_, cmd := agent.pressButton(btnReload)
+						return s, cmd
+					case "L", "u":
+						var cmd tea.Cmd
+						if key == "L" {
+							cmd = agent.startLock()
+						} else {
+							cmd = agent.startPassphrase("unlock")
+						}
+						var tabCmd tea.Cmd
+						if s.activeTab != 0 {
+							tabCmd = s.switchTab(0)
+						}
+						if agent.HasModal() {
+							s.navFocus = navFocusScreen
+						}
+						if tabCmd != nil {
+							return s, tea.Batch(tabCmd, cmd)
+						}
+						return s, cmd
 					}
-					return s, cmd
 				}
 			}
 		}
@@ -441,6 +473,9 @@ func (s *Skeleton) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "enter":
 				if agent := s.agentScreen(); agent != nil {
 					_, cmd := agent.pressButton(agent.buttons.Active)
+					if agent.HasModal() {
+						s.navFocus = navFocusScreen
+					}
 					return s, cmd
 				}
 				return s, nil
@@ -675,13 +710,15 @@ func (s *Skeleton) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if btn := agent.buttons.HandleMouse(msg.X, msg.Y); btn >= 0 {
 					cmd := s.SetTheme(s.themeBeforePicker)
 					s.showThemePicker = false
-					if s.navFocus != navFocusDaemon {
+					agent.buttons.Active = btn
+					_, pressCmd := agent.pressButton(btn)
+					if agent.HasModal() {
+						s.navFocus = navFocusScreen
+					} else if s.navFocus != navFocusDaemon {
 						s.navFocusBeforeDaemon = s.navFocus
 						s.activeTabBeforeDaemon = s.activeTab
 						s.navFocus = navFocusDaemon
 					}
-					agent.buttons.Active = btn
-					_, pressCmd := agent.pressButton(btn)
 					if s.activeTab != 0 {
 						return s, tea.Batch(cmd, s.switchTab(0), pressCmd)
 					}
@@ -759,13 +796,15 @@ func (s *Skeleton) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if agent := s.agentScreen(); agent != nil {
 			if btn := agent.buttons.HandleMouse(msg.X, msg.Y); btn >= 0 {
-				if s.navFocus != navFocusDaemon {
+				agent.buttons.Active = btn
+				_, cmd := agent.pressButton(btn)
+				if agent.HasModal() {
+					s.navFocus = navFocusScreen
+				} else if s.navFocus != navFocusDaemon {
 					s.navFocusBeforeDaemon = s.navFocus
 					s.activeTabBeforeDaemon = s.activeTab
 					s.navFocus = navFocusDaemon
 				}
-				agent.buttons.Active = btn
-				_, cmd := agent.pressButton(btn)
 				if s.activeTab != 0 {
 					return s, tea.Batch(s.switchTab(0), cmd)
 				}
@@ -785,7 +824,7 @@ func (s *Skeleton) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case agentStatusMsg, agentKeysMsg, agentDaemonStateMsg, agentLockResultMsg, agentUnlockResultMsg, foundKeysMsg, ButtonFlashDoneMsg:
+	case agentStatusMsg, agentKeysMsg, agentDaemonStateMsg, agentLockResultMsg, agentUnlockResultMsg, vaultStatusMsg, vaultPollMsg, foundKeysMsg, ButtonFlashDoneMsg:
 		updated, cmd := s.pages[0].model.Update(msg)
 		s.pages[0].model = updated
 		return s, cmd
@@ -962,6 +1001,24 @@ func (s *Skeleton) renderOuterFooter(w int) string {
 
 	var leftParts []string
 
+	// Vault/agent mode, with a padlock indicating live vault lock state when known.
+	modeLabel := strings.TrimSpace(s.agentBackendMode)
+	if s.vaultKnown {
+		modeLabel = s.vaultMode
+	}
+	if modeLabel != "" {
+		seg := modeLabel
+		segStyle := st.DimStyle
+		switch {
+		case s.vaultKnown && s.vaultMode == "vault" && s.vaultLocked:
+			seg = "🔒 " + modeLabel + " locked"
+			segStyle = st.WarnStyle
+		case s.vaultKnown && s.vaultMode == "vault":
+			seg = "🔓 " + modeLabel
+		}
+		leftParts = append(leftParts, segStyle.Render(seg))
+	}
+
 	for _, wd := range s.widgets {
 		if wd.value != "" {
 			leftParts = append(leftParts, st.DimStyle.Render(fmt.Sprintf("%s: %s", wd.id, wd.value)))
@@ -998,21 +1055,10 @@ func (s *Skeleton) renderOuterFooter(w int) string {
 	helpWidgetMarked := zone.Mark("footer-help", rightContent)
 
 	suffix := themeWidgetMarked + renderSep(sep) + helpWidgetMarked + renderSep(botR)
-	modeSeg := ""
-	if m := strings.TrimSpace(s.agentBackendMode); m != "" {
-		modeSeg = " " + st.DimStyle.Render(m) + " "
-	}
 	rightBlock := sizeInfo + renderSep(sep) + suffix
-	if modeSeg != "" {
-		rightBlock = sizeInfo + renderSep(sep) + modeSeg + renderSep(sep) + suffix
-	}
 
 	leftPrefix := renderSep(botL) + leftContent
 	fillW := w - lipgloss.Width(leftPrefix) - lipgloss.Width(rightBlock)
-	if fillW < 1 && modeSeg != "" {
-		rightBlock = sizeInfo + renderSep(sep) + suffix
-		fillW = w - lipgloss.Width(leftPrefix) - lipgloss.Width(rightBlock)
-	}
 	if fillW < 1 {
 		fillW = 1
 	}
@@ -1047,6 +1093,8 @@ func (s *Skeleton) View() tea.View {
 			st.HelpRow("s", "Start daemon"),
 			st.HelpRow("x", "Stop daemon"),
 			st.HelpRow("r", "Reload daemon"),
+			st.HelpRow("L", "Lock vault"),
+			st.HelpRow("u", "Unlock vault"),
 			"",
 			st.HelpRow("t", "Theme picker"),
 			"",

--- a/internal/tui/skeleton_footer_test.go
+++ b/internal/tui/skeleton_footer_test.go
@@ -1,0 +1,352 @@
+package tui
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	zone "github.com/lrstanley/bubblezone"
+	"github.com/ollykeran/sshush/internal/theme"
+)
+
+type footerTestModel struct{}
+
+func (m footerTestModel) Init() tea.Cmd                       { return nil }
+func (m footerTestModel) Update(tea.Msg) (tea.Model, tea.Cmd) { return m, nil }
+func (m footerTestModel) View() tea.View                      { return tea.NewView("") }
+
+func TestMain(m *testing.M) {
+	zone.NewGlobal()
+	os.Exit(m.Run())
+}
+
+func newFooterTestSkeleton() *Skeleton {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	sk.AddPage("test", "Test", footerTestModel{})
+	return sk
+}
+
+func TestRenderOuterFooterVaultPadlock(t *testing.T) {
+	sk := newFooterTestSkeleton()
+	sk.agentBackendMode = "vault"
+
+	tests := []struct {
+		name     string
+		mode     string
+		locked   bool
+		known    bool
+		wantLock string // padlock segment when locked; "" if no padlock
+		wantOpen string // padlock segment when unlocked; "" if no padlock
+	}{
+		{name: "unknown state shows mode without padlock", mode: "", locked: false, known: false, wantLock: "", wantOpen: ""},
+		{name: "locked vault shows warn padlock", mode: "vault", locked: true, known: true, wantLock: "🔒 vault locked", wantOpen: ""},
+		{name: "unlocked vault shows open padlock", mode: "vault", locked: false, known: true, wantLock: "", wantOpen: "🔓 vault"},
+		{name: "keys mode shows no padlock", mode: "keys", locked: false, known: true, wantLock: "", wantOpen: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sk.UpdateVaultState(tt.mode, tt.locked, tt.known)
+			foot := sk.renderOuterFooter(120)
+
+			if got := strings.Contains(foot, "🔒"); got != (tt.wantLock != "") {
+				t.Errorf("locked padlock present=%v want=%v\nfooter=%q", got, tt.wantLock != "", foot)
+			}
+			if got := strings.Contains(foot, "🔓"); got != (tt.wantOpen != "") {
+				t.Errorf("open padlock present=%v want=%v\nfooter=%q", got, tt.wantOpen != "", foot)
+			}
+			if tt.wantLock != "" && !strings.Contains(foot, tt.wantLock) {
+				t.Errorf("footer missing %q\nfooter=%q", tt.wantLock, foot)
+			}
+			if tt.wantOpen != "" && !strings.Contains(foot, tt.wantOpen) {
+				t.Errorf("footer missing %q\nfooter=%q", tt.wantOpen, foot)
+			}
+		})
+	}
+}
+
+func TestRenderOuterFooterModeMovedToLeft(t *testing.T) {
+	sk := newFooterTestSkeleton()
+	sk.agentBackendMode = "vault"
+	sk.UpdateVaultState("vault", false, true)
+
+	foot := sk.renderOuterFooter(120)
+	// The mode label should appear exactly once: in the left segment, not on the right.
+	if got := strings.Count(foot, "vault"); got != 1 {
+		t.Errorf("mode label 'vault' count = %d, want 1\nfooter=%q", got, foot)
+	}
+	// Footer chrome should still be present on the right.
+	for _, want := range []string{"[t] theme", "[?] help"} {
+		if !strings.Contains(foot, want) {
+			t.Errorf("footer missing %q\nfooter=%q", want, foot)
+		}
+	}
+}
+
+func TestAgentScreenVaultLockedStatus(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	screen := NewAgentScreen(sk, "", "/tmp/agent.sock")
+
+	updated, cmd := screen.Update(vaultStatusMsg{mode: "vault", reachable: true, locked: true})
+	sc := updated.(*AgentScreen)
+	if !sc.vaultLocked || !sc.vaultKnown {
+		t.Fatalf("vaultLocked=%v vaultKnown=%v, want true/true", sc.vaultLocked, sc.vaultKnown)
+	}
+	if sc.status != "vault locked - press u to unlock" || !sc.statusErr {
+		t.Errorf("status=%q err=%v, want locked warning", sc.status, sc.statusErr)
+	}
+	if cmd != nil {
+		t.Errorf("unexpected cmd: %v", cmd)
+	}
+	if !sc.sk.vaultLocked || !sc.sk.vaultKnown || sc.sk.vaultMode != "vault" {
+		t.Errorf("skeleton vault state not synced: %+v", sc.sk)
+	}
+
+	// A keys refresh while locked must keep the warning.
+	updated, _ = sc.Update(agentKeysMsg{refresh: true})
+	sc = updated.(*AgentScreen)
+	if sc.status != "vault locked - press u to unlock" || !sc.statusErr {
+		t.Errorf("keys refresh while locked: status=%q err=%v", sc.status, sc.statusErr)
+	}
+}
+
+func TestAgentScreenUnlockResetsCachedState(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	screen := NewAgentScreen(sk, "", "/tmp/agent.sock")
+
+	sc := screen
+	sc.vaultKnown = true
+	sc.vaultLocked = true
+
+	updated, _ := sc.Update(agentUnlockResultMsg{})
+	sc = updated.(*AgentScreen)
+	if sc.vaultKnown || sc.vaultLocked {
+		t.Errorf("after unlock result vaultKnown=%v vaultLocked=%v, want false/false", sc.vaultKnown, sc.vaultLocked)
+	}
+	if sc.status != "agent unlocked" || sc.statusErr {
+		t.Errorf("status=%q err=%v, want 'agent unlocked'", sc.status, sc.statusErr)
+	}
+}
+
+func TestAgentScreenVaultPollGeneration(t *testing.T) {
+	sk := NewSkeleton()
+	screen := NewAgentScreen(sk, "", "/tmp/agent.sock")
+
+	updated, cmd := screen.Update(agentDaemonStateMsg{running: true})
+	sc := updated.(*AgentScreen)
+	if cmd == nil {
+		t.Fatal("daemon start should arm a vault poll")
+	}
+	if sc.vaultPollGen != 1 {
+		t.Fatalf("vaultPollGen=%d, want 1", sc.vaultPollGen)
+	}
+
+	// A stale poll chain is dropped.
+	_, cmd = sc.Update(vaultPollMsg{gen: 0})
+	if cmd != nil {
+		t.Fatalf("stale poll produced cmd: %v", cmd)
+	}
+
+	// The current poll chain re-arms.
+	updated, cmd = sc.Update(vaultPollMsg{gen: 1})
+	if cmd == nil {
+		t.Fatal("current poll should re-arm")
+	}
+	sc = updated.(*AgentScreen)
+
+	// Daemon stop clears vault state and bumps the generation.
+	updated, _ = sc.Update(agentDaemonStateMsg{running: false})
+	sc = updated.(*AgentScreen)
+	if sc.vaultKnown || sc.vaultLocked {
+		t.Errorf("after stop vaultKnown=%v vaultLocked=%v, want false/false", sc.vaultKnown, sc.vaultLocked)
+	}
+	if sc.vaultPollGen != 2 {
+		t.Errorf("vaultPollGen=%d, want 2", sc.vaultPollGen)
+	}
+	if sc.sk.vaultKnown || sc.sk.vaultLocked {
+		t.Errorf("skeleton vault state not cleared after stop: %+v", sc.sk)
+	}
+}
+
+func TestAgentScreenLockUnlockButtons(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	screen := NewAgentScreen(sk, "", "/tmp/agent.sock")
+
+	labels := strings.Join(screen.buttons.Labels, ",")
+	if !strings.Contains(labels, "[L]ock") || !strings.Contains(labels, "[u]nlock") {
+		t.Fatalf("button labels %q missing lock/unlock", labels)
+	}
+
+	_, cmd := screen.pressButton(btnLock)
+	if !screen.showPass || screen.passAction != "lock" {
+		t.Errorf("after lock press showPass=%v action=%q, want true/'lock'", screen.showPass, screen.passAction)
+	}
+	if cmd == nil {
+		t.Error("lock press should return a focus cmd")
+	}
+	if screen.buttons.Pressed != -1 {
+		t.Errorf("lock press should not flash button, Pressed=%d", screen.buttons.Pressed)
+	}
+
+	sc := NewAgentScreen(sk, "", "/tmp/agent.sock")
+	_, cmd = sc.pressButton(btnUnlock)
+	if !sc.showPass || sc.passAction != "unlock" {
+		t.Errorf("after unlock press showPass=%v action=%q, want true/'unlock'", sc.showPass, sc.passAction)
+	}
+	if cmd == nil {
+		t.Error("unlock press should return a focus cmd")
+	}
+
+	sc = NewAgentScreen(sk, "", "/tmp/agent.sock")
+	_, cmd = sc.pressButton(btnStart)
+	if sc.showPass {
+		t.Error("start press should not open the passphrase modal")
+	}
+	if sc.status != "starting..." {
+		t.Errorf("status=%q, want 'starting...'", sc.status)
+	}
+	if sc.buttons.Pressed != btnStart {
+		t.Errorf("start press should flash button, Pressed=%d", sc.buttons.Pressed)
+	}
+	if cmd == nil {
+		t.Error("start press should return a cmd")
+	}
+}
+
+func TestAgentScreenLockVaultModeNeedsNoPassphrase(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+
+	// Vault mode: lock is immediate, no passphrase prompt.
+	agent := NewAgentScreen(sk, "", "/tmp/agent.sock")
+	agent.vaultMode = "vault"
+	_, cmd := agent.pressButton(btnLock)
+	if agent.showPass {
+		t.Error("vault-mode lock should not open the passphrase prompt")
+	}
+	if agent.passAction != "" {
+		t.Errorf("passAction=%q, want empty", agent.passAction)
+	}
+	if agent.status != "locking..." {
+		t.Errorf("status=%q, want 'locking...'", agent.status)
+	}
+	if cmd == nil {
+		t.Error("vault-mode lock should return a lock cmd")
+	}
+	if agent.buttons.Pressed != -1 {
+		t.Errorf("vault-mode lock should not flash button, Pressed=%d", agent.buttons.Pressed)
+	}
+
+	// Keys mode (or unknown mode): lock still needs a passphrase prompt.
+	agent = NewAgentScreen(sk, "", "/tmp/agent.sock")
+	agent.vaultMode = "keys"
+	_, cmd = agent.pressButton(btnLock)
+	if !agent.showPass || agent.passAction != "lock" {
+		t.Errorf("keys-mode lock: showPass=%v action=%q, want true/'lock'", agent.showPass, agent.passAction)
+	}
+	if cmd == nil {
+		t.Error("keys-mode lock should return a focus cmd")
+	}
+}
+
+func TestSkeletonDaemonFocusLockUnlock(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	agent := NewAgentScreen(sk, "", "/tmp/agent.sock")
+	sk.AddPage("agent", "Agent", agent)
+
+	for _, tc := range []struct {
+		key    rune
+		action string
+	}{
+		{key: 'L', action: "lock"},
+		{key: 'u', action: "unlock"},
+	} {
+		t.Run(string(tc.key), func(t *testing.T) {
+			agent.showPass = false
+			sk.navFocus = navFocusDaemon
+			_, cmd := sk.Update(tea.KeyPressMsg{Code: tc.key})
+			if cmd == nil {
+				t.Fatal("daemon-focus hotkey should return a focus cmd")
+			}
+			if sk.navFocus != navFocusScreen {
+				t.Errorf("navFocus=%v, want navFocusScreen", sk.navFocus)
+			}
+			if !agent.showPass || agent.passAction != tc.action {
+				t.Errorf("showPass=%v action=%q, want true/%q", agent.showPass, agent.passAction, tc.action)
+			}
+		})
+	}
+}
+
+func TestSkeletonGlobalLockUnlockHotkeys(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	agent := NewAgentScreen(sk, "", "/tmp/agent.sock")
+	sk.AddPage("agent", "Agent", agent)
+	sk.AddPage("create", "Create", NewCreateScreen(sk))
+
+	// From the nav bar on the agent tab.
+	sk.activeTab = 0
+	sk.navFocus = navFocusTabs
+	_, cmd := sk.Update(tea.KeyPressMsg{Code: 'L'})
+	if cmd == nil {
+		t.Fatal("global L from nav bar should return a focus cmd")
+	}
+	if !agent.showPass || agent.passAction != "lock" {
+		t.Errorf("global L: showPass=%v action=%q, want true/'lock'", agent.showPass, agent.passAction)
+	}
+	if sk.navFocus != navFocusScreen {
+		t.Errorf("global L: navFocus=%v, want navFocusScreen", sk.navFocus)
+	}
+
+	// From another tab, focus in the nav bar.
+	agent.showPass = false
+	sk.activeTab = 1
+	sk.navFocus = navFocusTabs
+	_, cmd = sk.Update(tea.KeyPressMsg{Code: 'u'})
+	if cmd == nil {
+		t.Fatal("global u from another tab should return a focus cmd")
+	}
+	if sk.activeTab != 0 {
+		t.Errorf("global u: activeTab=%d, want 0", sk.activeTab)
+	}
+	if !agent.showPass || agent.passAction != "unlock" {
+		t.Errorf("global u: showPass=%v action=%q, want true/'unlock'", agent.showPass, agent.passAction)
+	}
+	if sk.navFocus != navFocusScreen {
+		t.Errorf("global u: navFocus=%v, want navFocusScreen", sk.navFocus)
+	}
+}
+
+func TestSkeletonDaemonFocusEnterLockButton(t *testing.T) {
+	sk := NewSkeleton()
+	sk.theme = theme.DefaultTheme()
+	sk.styles = BuildStyles(sk.theme)
+	agent := NewAgentScreen(sk, "", "/tmp/agent.sock")
+	sk.AddPage("agent", "Agent", agent)
+	sk.navFocus = navFocusDaemon
+	agent.buttons.Active = btnLock
+
+	_, cmd := sk.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on lock button should return a focus cmd")
+	}
+	if sk.navFocus != navFocusScreen {
+		t.Errorf("navFocus=%v, want navFocusScreen", sk.navFocus)
+	}
+	if !agent.showPass || agent.passAction != "lock" {
+		t.Errorf("showPass=%v action=%q, want true/'lock'", agent.showPass, agent.passAction)
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -16,6 +16,7 @@ type Styles struct {
 	InactiveTabStyle          lipgloss.Style
 	FocusedBorderStyle        lipgloss.Style
 	UnfocusedBorderStyle      lipgloss.Style
+	WarnBorderStyle           lipgloss.Style
 	SectionTitleStyle         lipgloss.Style
 	FocusedButtonStyle        lipgloss.Style
 	UnfocusedButtonStyle      lipgloss.Style
@@ -100,6 +101,11 @@ func BuildStyles(t theme.Theme) Styles {
 		UnfocusedBorderStyle: lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
 			BorderForeground(accent).
+			Padding(0, 1),
+		WarnBorderStyle: lipgloss.NewStyle().
+			BorderStyle(lipgloss.RoundedBorder()).
+			BorderForeground(warnClr).
+			Bold(true).
 			Padding(0, 1),
 		SectionTitleStyle: lipgloss.NewStyle().
 			Bold(true).


### PR DESCRIPTION
## What

Makes the agent tab vault-lock aware and lets you lock/unlock without leaving the TUI.

## Changes

- **Footer**: live backend mode with a padlock (🔓 unlocked / 🔒 locked, warn-styled), instead of the static config mode in the footer-right.
- **Key table**: warn-coloured border plus a `vault locked - press u to unlock` status while the vault agent is locked.
- **Daemon header**: new `[L]ock` / `[u]nlock` buttons next to Start/Stop/Reload.
- **Global hotkeys**: `L` locks, `u` unlocks (from any tab, when not typing). Locking a vault agent is **instant** — the daemon wipes the in-memory master key, so no passphrase is needed. Keys-mode locking still prompts, since that passphrase becomes the unlock key.
- **Live state**: polls the running agent every 2s for backend mode + lock state; poll chains are generation-tagged so daemon start/stop drops stale chains.

## Tests

- Footer padlock/mode rendering, poll generation/stale-drop/daemon-stop
- Lock/unlock buttons, daemon-focus enter, global `L`/`u` hotkeys (nav bar + cross-tab)
- Vault-mode lock requires no passphrase; keys-mode still prompts

gofmt, go vet, go test (incl. e2e) and golangci-lint all pass.